### PR TITLE
Rename MutPixels to PixelsMut

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-use std::slice::{Chunks, MutChunks};
+use std::slice::{Chunks, ChunksMut};
 use std::any::Any;
 use std::num::Int;
 use std::intrinsics::TypeId;
@@ -136,11 +136,11 @@ where T: Primitive, PixelType: Pixel<T> {
 }
 
 /// Iterate over mutable pixel refs.
-pub struct MutPixels<'a, T: 'static, Sized? PixelType> {
-    chunks: MutChunks<'a, T>
+pub struct PixelsMut<'a, T: 'static, Sized? PixelType> {
+    chunks: ChunksMut<'a, T>
 }
 
-impl<'a, T, PixelType> Iterator<&'a mut PixelType> for MutPixels<'a, T, PixelType>
+impl<'a, T, PixelType> Iterator<&'a mut PixelType> for PixelsMut<'a, T, PixelType>
 where T: Primitive, PixelType: Pixel<T> {
     #[inline(always)]
     fn next(&mut self) -> Option<&'a mut PixelType> {
@@ -150,7 +150,7 @@ where T: Primitive, PixelType: Pixel<T> {
     }
 }
 
-impl<'a, T, PixelType> DoubleEndedIterator<&'a mut PixelType> for MutPixels<'a, T, PixelType>
+impl<'a, T, PixelType> DoubleEndedIterator<&'a mut PixelType> for PixelsMut<'a, T, PixelType>
 where T: Primitive, PixelType: Pixel<T> {
     #[inline(always)]
     fn next_back(&mut self) -> Option<&'a mut PixelType> {
@@ -187,15 +187,15 @@ where T: Primitive, PixelType: Pixel<T> {
 }
 
 /// Enumerate the pixels of an image. 
-pub struct EnumerateMutPixels<'a, T: 'static, Sized? PixelType> {
-    pixels: MutPixels<'a, T, PixelType>,
+pub struct EnumeratePixelsMut<'a, T: 'static, Sized? PixelType> {
+    pixels: PixelsMut<'a, T, PixelType>,
     x:      u32,
     y:      u32,
     width:  u32
 }
 
 impl<'a, T, PixelType> Iterator<(u32, u32, &'a mut PixelType)>
-for EnumerateMutPixels<'a, T, PixelType>
+for EnumeratePixelsMut<'a, T, PixelType>
 where T: Primitive, PixelType: Pixel<T> {
     #[inline(always)]
     fn next(&mut self) -> Option<(u32, u32, &'a mut PixelType)> {
@@ -288,8 +288,8 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// Returns an iterator over the mutable pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with a mutable reference to them.
-    pub fn pixels_mut(&mut self) -> MutPixels<T, PixelType> {
-        MutPixels {
+    pub fn pixels_mut(&mut self) -> PixelsMut<T, PixelType> {
+        PixelsMut {
             chunks: self.data.as_mut_slice().chunks_mut(
                 Pixel::channel_count(None::<&PixelType>) as uint
             )
@@ -309,9 +309,9 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     }
 
     /// Enumerates over the pixels of the image.
-    pub fn enumerate_pixels_mut<'a>(&'a mut self) -> EnumerateMutPixels<'a, T, PixelType> {
+    pub fn enumerate_pixels_mut<'a>(&'a mut self) -> EnumeratePixelsMut<'a, T, PixelType> {
         let width = self.width;
-        EnumerateMutPixels {
+        EnumeratePixelsMut {
             pixels: self.pixels_mut(),
             x: 0,
             y: 0,


### PR DESCRIPTION
This follows the rename of `slice::MutChunks` into `slice::ChunksMut` (and fixes the compile error due to that rename) to adhere to naming conventions.