### PR TITLE
Upgrade to latest Rust

### DIFF
--- a/src/gif/bits.rs
+++ b/src/gif/bits.rs
@@ -31,7 +31,7 @@ impl<R: Reader> BitReader<R> {
         }
         // FIXME: 64bit won't work this way
         while self.bits < n {
-            self.buf |= try!(self.r.read_byte()) as u64 << self.bits as uint;
+            self.buf |= (try!(self.r.read_byte()) as u64) << self.bits as uint;
             self.bits += 8;
         }
         Ok(())
@@ -101,7 +101,7 @@ impl<'a, W> BitWriter<'a, W> where W: Writer + 'a {
     /// Returns the next `n` bits.
     pub fn write_bits(&mut self, mut v: u32, mut n: u8) -> io::IoResult<()> {
         while n > 0 {
-            self.buf |= v as u8 << self.bits as uint;
+            self.buf |= (v as u8) << self.bits as uint;
             let missing = 8u8 - self.bits;
             if n >= missing {
                 n -= missing;

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -270,7 +270,7 @@ impl<W: Writer> JPEGEncoder<W> {
     }
 
     fn write_bits(&mut self, bits: u16, size: u8) -> IoResult<()> {
-        self.accumulator |= bits as u32 << (32 - (self.nbits + size)) as uint;
+        self.accumulator |= (bits as u32) << (32 - (self.nbits + size)) as uint;
         self.nbits += size;
 
         while self.nbits >= 8 {

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -41,7 +41,7 @@ impl HuffDecoder {
                 }
             }
 
-            self.bits |= (byte as u32 << (32 - 8)) >> self.num_bits as uint;
+            self.bits |= ((byte as u32) << (32 - 8)) >> self.num_bits as uint;
             self.num_bits += 8;
         }
 

--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -371,7 +371,7 @@ impl<R: Reader> HuffReader<R> {
         while self.num_bits < n {
             let byte = try!(self.r.read_u8());
 
-            self.bits |= byte as u32 << self.num_bits as uint;
+            self.bits |= (byte as u32) << self.num_bits as uint;
             self.num_bits += 8;
         }
 

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -893,7 +893,7 @@ impl<R: Reader> VP8Decoder<R> {
             let sizes = try!(self.r.read_exact(3 * n - 3));
 
             for (i, s) in sizes.as_slice().chunks(3).enumerate() {
-                let size = s[0] as u32 + (s[1] as u32 << 8) + (s[2] as u32 << 8);
+                let size = s[0] as u32 + ((s[1] as u32) << 8) + ((s[2] as u32) << 8);
                 let buf  = try!(self.r.read_exact(size as uint));
 
                 self.partitions[i].init(buf);
@@ -1026,7 +1026,7 @@ impl<R: Reader> VP8Decoder<R> {
         self.frame.for_display = (tag[0] >> 4) & 1 != 0;
 
         let first_partition_size = (
-            (tag[2] as u32 << 16) | (tag[1] as u32 << 8) | tag[0] as u32) >> 5;
+            ((tag[2] as u32) << 16) | ((tag[1] as u32) << 8) | tag[0] as u32) >> 5;
 
         if self.frame.keyframe {
             let _ = try!(self.r.read(&mut tag));


### PR DESCRIPTION
Rust's [9c3e608](https://github.com/rust-lang/rust/commit/9c3e608) broke code of the form `x as y << z`, which now has to be written `(x as y) << z`.