### PR TITLE
Use unboxed closures.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -83,26 +83,26 @@ pub trait Pixel<T>: Copy + Clone {
     fn to_luma_alpha(&self) -> LumaA<T>;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn map(&self, f: | T | -> T) -> Self;
+    fn map<F>(&self, f: F) -> Self where F: Fn(T) -> T;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn apply(&mut self, f: | T | -> T);
+    fn apply<F>(&mut self, f: F) where F: Fn(T) -> T;
 
     /// Apply the function f to each channel except the alpha channel.
     /// Apply the function g to the alpha channel.
-    fn map_with_alpha(&self, f: |T| -> T, g: |T| -> T) -> Self;
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self where F: Fn(T) -> T, G: Fn(T) -> T;
 
     /// Apply the function f to each channel except the alpha channel.
     /// Apply the function g to the alpha channel. Works in-place.
-    fn apply_with_alpha(&mut self, f: |T| -> T, g: |T| -> T);
+    fn apply_with_alpha<F, G>(&mut self, f: F, g: G) where F: Fn(T) -> T, G: Fn(T) -> T;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise.
-    fn map2(&self, other: &Self, f: | T, T | -> T) -> Self;
+    fn map2<F>(&self, other: &Self, f: F) -> Self where F: Fn(T, T) -> T;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise. Works in-place.
-    fn apply2(&mut self, other: &Self, f: | T, T | -> T);
+    fn apply2<F>(&mut self, other: &Self, f: F) where F: Fn(T, T) -> T;
 
     /// Invert this pixel
     fn invert(&mut self);
@@ -463,7 +463,7 @@ where T: Primitive + 'static, PixelType: Pixel<T> + 'static {
 
     /// Constructs a new ImageBuffer by repeated application of the supplied function.
     /// The arguments to the function are the pixel's x and y coordinates.
-    pub fn from_fn(width: u32, height: u32, f: | u32, u32 | -> PixelType) -> ImageBuffer<Vec<T>, T, PixelType> {
+    pub fn from_fn(width: u32, height: u32, f: Box<Fn(u32, u32) -> PixelType>) -> ImageBuffer<Vec<T>, T, PixelType> {
         let mut buf = ImageBuffer::new(width, height);
         for (x, y,  p) in buf.enumerate_pixels_mut() {
             *p = f(x, y)

--- a/src/color.rs
+++ b/src/color.rs
@@ -143,27 +143,27 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
         pix
     }
 
-    fn map(& self, f: | T | -> T) -> $ident<T> {
+    fn map<F>(& self, f: F) -> $ident<T> where F: Fn(T) -> T {
         let mut this = (*self).clone();
         this.apply(f);
         this
     }
 
-    fn apply(&mut self, f: | T | -> T) {
+    fn apply<F>(&mut self, f: F) where F: Fn(T) -> T {
         let &$ident(ref mut this) = self;
         for v in this.as_mut_slice().iter_mut() {
             *v = f(*v)
         }
     }
 
-    fn map_with_alpha(& self, f: |T| -> T, g: |T| -> T) -> $ident<T> {
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> $ident<T> where F: Fn(T) -> T, G: Fn(T) -> T {
         let mut this = (*self).clone();
         this.apply_with_alpha(f, g);
         this
     }
 
     #[allow(unused_typecasts)]
-    fn apply_with_alpha(&mut self, f: |T| -> T, g: |T| -> T) {
+    fn apply_with_alpha<F, G>(&mut self, f: F, g: G) where F: Fn(T) -> T, G: Fn(T) -> T {
         let &$ident(ref mut this) = self;
         for v in this.as_mut_slice().slice_to_mut($channels as uint-$alphas as uint).iter_mut() {
             *v = f(*v)
@@ -174,13 +174,13 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
         }
     }
 
-    fn map2(&self, other: &$ident<T>, f: | T, T | -> T) -> $ident<T> {
+    fn map2<F>(&self, other: &Self, f: F) -> $ident<T> where F: Fn(T, T) -> T {
         let mut this = (*self).clone();
         this.apply2(other, f);
         this
     }
 
-    fn apply2(&mut self, other: &$ident<T>, f: | T, T | -> T) {
+    fn apply2<F>(&mut self, other: &$ident<T>, f: F) where F: Fn(T, T) -> T {
         let &$ident(ref mut this) = self;
         let &$ident(ref that) = other;
         for (a, &b) in this.iter_mut().zip(that.iter()) {

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -71,7 +71,7 @@ pub fn contrast<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
 
     for y in range(0, height) {
         for x in range(0, width) {
-            let f = image.get_pixel(x, y).map(|b| {
+            let f = image.get_pixel(x, y).map(|&: b| {
                 let c = cast::<P, f32>(b).unwrap();
 
                 let d = ((c / max - 0.5) * percent  + 0.5) * max;
@@ -102,12 +102,12 @@ pub fn brighten<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
 
     for y in range(0, height) {
         for x in range(0, width) {
-            let e = image.get_pixel(x, y).map_with_alpha(|b| {
+            let e = image.get_pixel(x, y).map_with_alpha(|&:b| {
                 let c = cast::<P, i32>(b).unwrap();
                 let d = clamp(c + value, 0, max);
 
                 cast::<i32, P>(d).unwrap()
-            }, |alpha| alpha);
+            }, |&:alpha| alpha);
 
             out.put_pixel(x, y, e);
         }

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -109,7 +109,7 @@ mod tests {
     /// Test that images written into other images works
     fn test_image_in_image() {
         let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_fn(16, 16, |_, _| {
+        let source = ImageBuffer::from_fn(16, 16, box |&: _, _| {
             Rgb([255u8, 0, 0])
         });
         overlay(&mut target, &source, 0, 0);
@@ -124,7 +124,7 @@ mod tests {
     /// Test that images written outside of a frame doesn't blow up
     fn test_image_in_image_outside_of_bounds() {
         let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_fn(32, 32, |_, _| {
+        let source = ImageBuffer::from_fn(32, 32, box |&: _, _| {
             Rgb([255u8, 0, 0])
         });
         overlay(&mut target, &source, 1, 1);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -40,9 +40,9 @@ pub enum FilterType {
 }
 
 /// A Representation of a separable filter.
-pub struct Filter < 'a> {
+pub struct Filter <'a> {
     /// The filter's filter function.
-    pub kernel:  | f32 | : 'a -> f32,
+    pub kernel: Box<Fn(f32) -> f32 + 'a>,
 
     /// The window on which this filter operates.
     pub support: f32
@@ -335,7 +335,7 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
     P = Primitive::max_value();
     let max = cast::<P, f32>(max).unwrap();
 
-    let sum = kernel.iter().fold(0.0, | a, f | a + *f);
+    let sum = kernel.iter().fold(0.0, |&: a, f| a + *f);
 
     let sum = if sum == 0.0 {
         1.0
@@ -406,23 +406,23 @@ pub fn resize<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>
 
     let mut method = match filter {
         FilterType::Nearest    =>   Filter {
-            kernel: |x| box_kernel(x),
+            kernel: box |&: x| box_kernel(x),
             support: 0.5
         },
         FilterType::Triangle   => Filter {
-            kernel: |x| triangle_kernel(x),
+            kernel: box |&: x| triangle_kernel(x),
             support: 1.0
         },
         FilterType::CatmullRom => Filter {
-            kernel: |x| catmullrom_kernel(x),
+            kernel: box |&: x| catmullrom_kernel(x),
             support: 2.0
         },
         FilterType::Gaussian   => Filter {
-            kernel: |x| gaussian_kernel(x),
+            kernel: box |&: x| gaussian_kernel(x),
             support: 3.0
         },
         FilterType::Lanczos3   => Filter {
-            kernel: |x| lanczos3_kernel(x),
+            kernel: box |&: x| lanczos3_kernel(x),
             support: 3.0
         },
 };
@@ -444,7 +444,7 @@ pub fn blur<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
     };
 
     let mut method = Filter {
-        kernel: |x| gaussian(x, sigma),
+        kernel: box |&: x| gaussian(x, sigma),
         support: 2.0 * sigma
     };
 
@@ -475,7 +475,7 @@ pub fn unsharpen<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<
             let a = image.get_pixel(x, y);
             let b = tmp.get_pixel_mut(x, y);
 
-            let p = a.map2(b, | c, d | {
+            let p = a.map2(b, |&: c, d| {
                 let ic = cast::<A, i32>(c).unwrap();
                 let id = cast::<A, i32>(d).unwrap();
 


### PR DESCRIPTION
This fixes build errors with rustc nightly, now that boxed closures have been removed.