### PR TITLE
Fixes for 1.0 alpha

### DIFF
--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -19,10 +19,10 @@ fn main() {
     let im = image::open(&Path::new(file.clone())).unwrap();
 
     //The dimensions method returns the images width and height
-    println!("dimensions {}", im.dimensions());
+    println!("dimensions {:?}", im.dimensions());
 
     //The color method returns the image's ColorType
-    println!("{}", im.color());
+    println!("{:?}", im.color());
 
     let fout = File::create(&Path::new(format!("{}.png", os::args().as_slice()[1]))).unwrap();
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -5,7 +5,7 @@ use buffer::RgbaImage;
 /// Hold the frames of the animated image
 pub struct Frames {
     frames: Vec<Frame>,
-    current_frame: uint,
+    current_frame: usize,
 }
 
 impl Frames {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -28,8 +28,8 @@ impl<T> AsMutSlice<T> for Vec<T> {
 }
 
 /// And array-like type that behaves like Vec<T> or [T].
-pub trait ArrayLike<T>: Index<uint, Output=T> + IndexMut<uint, Output=T> + AsSlice<T> + AsMutSlice<T> {}
-impl<A: Index<uint, Output=T> + IndexMut<uint, Output=T> + AsSlice<T> + AsMutSlice<T>, T> ArrayLike<T> for A { }
+pub trait ArrayLike<T>: Index<usize, Output=T> + IndexMut<usize, Output=T> + AsSlice<T> + AsMutSlice<T> {}
+impl<A: Index<usize, Output=T> + IndexMut<usize, Output=T> + AsSlice<T> + AsMutSlice<T>, T> ArrayLike<T> for A { }
 
 /// A generalized pixel.
 ///
@@ -237,9 +237,9 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// (for example a `Vec` or a slice)
     /// Returns None if the container is not big enough
     pub fn from_raw(width: u32, height: u32, buf: Container) -> Option<ImageBuffer<Container, T, PixelType>> {
-        if width as uint 
-           * height as uint
-           * Pixel::channel_count(None::<&PixelType>) as uint 
+        if width as usize 
+           * height as usize
+           * Pixel::channel_count(None::<&PixelType>) as usize 
            <= buf.as_slice().len() {
             Some(ImageBuffer {
                 data: buf,
@@ -286,7 +286,7 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     pub fn pixels<'a>(&'a self) -> Pixels<'a, T, PixelType> {
         Pixels {
             chunks: self.data.as_slice().chunks(
-                Pixel::channel_count(None::<&PixelType>) as uint
+                Pixel::channel_count(None::<&PixelType>) as usize
             )
         }
     }
@@ -297,7 +297,7 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     pub fn pixels_mut(&mut self) -> PixelsMut<T, PixelType> {
         PixelsMut {
             chunks: self.data.as_mut_slice().chunks_mut(
-                Pixel::channel_count(None::<&PixelType>) as uint
+                Pixel::channel_count(None::<&PixelType>) as usize
             )
         }
     }
@@ -331,8 +331,8 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     pub fn get_pixel(&self, x: u32, y: u32) -> &PixelType {
-        let no_channels = Pixel::channel_count(None::<&PixelType>) as uint;
-        let index  = no_channels * (y * self.width + x) as uint;
+        let no_channels = Pixel::channel_count(None::<&PixelType>) as usize;
+        let index  = no_channels * (y * self.width + x) as usize;
         Pixel::from_slice(
             None::<&PixelType>,
             self.data.as_slice().slice(
@@ -347,8 +347,8 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut PixelType {
-        let no_channels = Pixel::channel_count(None::<&PixelType>) as uint;
-        let index  = no_channels * (y * self.width + x) as uint;
+        let no_channels = Pixel::channel_count(None::<&PixelType>) as usize;
+        let index  = no_channels * (y * self.width + x) as usize;
         Pixel::from_slice_mut(
             None::<&PixelType>,
             self.data.as_mut_slice().slice_mut(
@@ -444,7 +444,7 @@ where T: Primitive + 'static, PixelType: Pixel<T> + 'static {
                     (width as u64
                      * height as u64 
                      * (Pixel::channel_count(None::<&PixelType>) as u64)
-                    ) as uint
+                    ) as usize
                 ).collect(),
             width: width,
             height: height,
@@ -516,7 +516,7 @@ impl GreyImage {
         };
         let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
         for (pixel, &idx) in buffer.pixels_mut().rev().zip(indicies.iter().rev()) {
-            let (r, g, b) = palette[idx as uint];
+            let (r, g, b) = palette[idx as usize];
             let alpha = if let Some(t_idx) = transparent_idx {
                 if t_idx == idx {
                     0

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -337,7 +337,7 @@ impl DynamicImage {
             }
 
             _ => Err(image::ImageError::UnsupportedError(
-                     format!("An encoder for {} is not available.", format))
+                     format!("An encoder for {:?} is not available.", format))
                  ),
         };
 
@@ -410,8 +410,8 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
         }
         (color::ColorType::Grey(bit_depth), U8(ref buf)) if bit_depth == 1 || bit_depth == 2 || bit_depth == 4 => {
             // Note: this conversion assumes that the scanlines begin on byte boundaries 
-            let mask = (1u8 << bit_depth as uint) - 1;
-            let scaling_factor = (255)/((1 << bit_depth as uint) - 1);
+            let mask = (1u8 << bit_depth as usize) - 1;
+            let scaling_factor = (255)/((1 << bit_depth as usize) - 1);
             let skip = (w % 8)/bit_depth as u32;
             let row_len = w + skip;
             let p = buf.as_slice()
@@ -424,9 +424,9 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
                        ))
                        // skip the pixels that can be neglected because scanlines should
                        // start at byte boundaries
-                       .enumerate().filter(|&(i, _)| i % (row_len as uint) < (w as uint) ).map(|(_, p)| p)
+                       .enumerate().filter(|&(i, _)| i % (row_len as usize) < (w as usize) ).map(|(_, p)| p)
                        .map(|(shift, pixel)|
-                           (pixel & mask << shift as uint) >> shift as uint
+                           (pixel & mask << shift as usize) >> shift as usize
                        )
                        .map(|pixel| pixel * scaling_factor)
                        .collect();
@@ -483,7 +483,7 @@ pub fn open(path: &Path) -> ImageResult<DynamicImage> {
         "tiff" => image::ImageFormat::TIFF,
         "tga" => image::ImageFormat::TGA,
         format => return Err(image::ImageError::UnsupportedError(format!(
-            "Image format image/{} is not supported.", 
+            "Image format image/{:?} is not supported.", 
             format
         )))
     };
@@ -511,7 +511,7 @@ pub fn save_buffer(path: &Path, buf: &[u8], width: u32, height: u32, color: colo
             kind: io::InvalidInput,
             desc: "Unsupported image format.",
             detail: Some(format!(
-                "Image format image/{} is not supported.", 
+                "Image format image/{:?} is not supported.", 
                 format
             ))
         })
@@ -527,7 +527,7 @@ pub fn load<R: Reader+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIma
         image::ImageFormat::WEBP => decoder_to_image(webp::WebpDecoder::new(io::BufferedReader::new(r))),
         image::ImageFormat::TIFF => decoder_to_image(try!(tiff::TIFFDecoder::new(r))),
         image::ImageFormat::TGA => decoder_to_image(tga::TGADecoder::new(r)),
-        _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {} is not available.", format))),
+        _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }
 

--- a/src/gif/bits.rs
+++ b/src/gif/bits.rs
@@ -31,7 +31,7 @@ impl<R: Reader> BitReader<R> {
         }
         // FIXME: 64bit won't work this way
         while self.bits < n {
-            self.buf |= (try!(self.r.read_byte()) as u64) << self.bits as uint;
+            self.buf |= (try!(self.r.read_byte()) as u64) << self.bits as usize;
             self.bits += 8;
         }
         Ok(())
@@ -40,12 +40,12 @@ impl<R: Reader> BitReader<R> {
     /// Returns the next `n` bits without consuming them.
     pub fn peek_bits(&mut self, n: u8) -> io::IoResult<u64> {
         try!(self.fill_cache(n));
-        let mask = (1 << n as uint) - 1;
+        let mask = (1 << n as usize) - 1;
         Ok(self.buf & mask)
     }
     
     fn consume(&mut self, n: u8) {
-        self.buf >>= n as uint;
+        self.buf >>= n as usize;
         self.bits -= n;
     }
 
@@ -64,7 +64,7 @@ impl<R: Reader> BitReader<R> {
 }
 
 impl<R: Reader> Reader for BitReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
+    fn read(&mut self, buf: &mut [u8]) -> io::IoResult<usize> {
         if self.is_aligned() {
             self.r.read(buf)
         } else {
@@ -101,11 +101,11 @@ impl<'a, W> BitWriter<'a, W> where W: Writer + 'a {
     /// Returns the next `n` bits.
     pub fn write_bits(&mut self, mut v: u32, mut n: u8) -> io::IoResult<()> {
         while n > 0 {
-            self.buf |= (v as u8) << self.bits as uint;
+            self.buf |= (v as u8) << self.bits as usize;
             let missing = 8u8 - self.bits;
             if n >= missing {
                 n -= missing;
-                v >>= missing as uint;
+                v >>= missing as usize;
                 try!(self.w.write_u8(self.buf));
                 self.bits = 0;
                 self.buf = 0;

--- a/src/gif/lzw.rs
+++ b/src/gif/lzw.rs
@@ -24,14 +24,14 @@ impl DecodingDict {
         DecodingDict {
             min_size: min_size,
             table: Vec::with_capacity(512),
-            buffer: Vec::with_capacity((1 << MAX_CODESIZE as uint) - 1)
+            buffer: Vec::with_capacity((1 << MAX_CODESIZE as usize) - 1)
         }
     }
 
     /// Resets the dictionary
     fn reset(&mut self) {
         self.table.clear();
-        for i in range(0, (1u16 << self.min_size as uint)) {
+        for i in range(0, (1u16 << self.min_size as usize)) {
             self.table.push((None, i as u8));
         }
     }
@@ -48,8 +48,8 @@ impl DecodingDict {
         let mut code = code;
         let mut cha;
         while let Some(k) = code {
-            //(code, cha) = self.table[k as uint];
-            let entry = self.table[k as uint]; code = entry.0; cha = entry.1;
+            //(code, cha) = self.table[k as usize];
+            let entry = self.table[k as usize]; code = entry.0; cha = entry.1;
             self.buffer.push(cha);
         }
         self.buffer.reverse();
@@ -74,7 +74,7 @@ pub fn decode<R, W>(r: R, w: &mut W, min_code_size: u8) -> io::IoResult<()>
 where R: Reader, W: Writer {
     let mut prev = None;
     let mut r = BitReader::new(r);
-    let clear_code = 1 << min_code_size as uint;
+    let clear_code = 1 << min_code_size as usize;
     let end_code = clear_code + 1;
     let mut table = DecodingDict::new(min_code_size);
     let mut code_size = min_code_size + 1;
@@ -113,7 +113,7 @@ where R: Reader, W: Writer {
                 };
                 try!(w.write(data));
             }
-            if next_code == (1 << code_size as uint) - 1
+            if next_code == (1 << code_size as usize) - 1
                && code_size < MAX_CODESIZE {
                 code_size += 1;
             }

--- a/src/image.rs
+++ b/src/image.rs
@@ -99,7 +99,7 @@ pub trait ImageDecoder: Sized {
     fn colortype(&mut self) -> ImageResult<ColorType>;
 
     /// Returns the length in bytes of one decoded row of the image
-    fn row_len(&mut self) -> ImageResult<uint>;
+    fn row_len(&mut self) -> ImageResult<usize>;
     
     /// Returns true if the image is animated
     fn is_animated(&mut self) -> ImageResult<bool> {
@@ -137,7 +137,7 @@ pub trait ImageDecoder: Sized {
 
         let rowlen  = try!(self.row_len());
 
-        let mut buf = repeat(0u8).take(length as uint * width as uint * bpp).collect::<Vec<u8>>();
+        let mut buf = repeat(0u8).take(length as usize * width as usize * bpp).collect::<Vec<u8>>();
         let mut tmp = repeat(0u8).take(rowlen).collect::<Vec<u8>>();
 
         loop {
@@ -148,13 +148,13 @@ pub trait ImageDecoder: Sized {
             }
         }
 
-        for i in range(0, length as uint) {
+        for i in range(0, length as usize) {
             {
-                let from = tmp.slice_from(x as uint * bpp)
-                              .slice_to(width as uint * bpp);
+                let from = tmp.slice_from(x as usize * bpp)
+                              .slice_to(width as usize * bpp);
 
-                let to   = buf.slice_from_mut(i * width as uint * bpp)
-                              .slice_to_mut(width as uint * bpp);
+                let to   = buf.slice_from_mut(i * width as usize * bpp)
+                              .slice_to_mut(width as usize * bpp);
 
                 slice::bytes::copy_memory(to, from);
             }
@@ -176,6 +176,7 @@ pub struct Pixels<'a, I:'a> {
     height: u32
 }
 
+#[old_impl_check]
 impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> Iterator for Pixels<'a, I> {
     type Item = (u32, u32, P);
     fn next(&mut self) -> Option<(u32, u32, P)> {
@@ -207,6 +208,7 @@ pub struct MutPixels<'a, I:'a> {
     height: u32
 }
 
+#[old_impl_check]
 impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> Iterator for MutPixels<'a, I> {
     type Item = (u32, u32, &'a mut P);
     fn next(&mut self) -> Option<(u32, u32, &'a mut P)> {
@@ -311,6 +313,7 @@ pub struct SubImage <'a, I:'a> {
     ystride: u32,
 }
 
+#[old_impl_check]
 impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubImage<'a, I> {
     /// Construct a new subimage
     pub fn new(image: &mut I, x: u32, y: u32, width: u32, height: u32) -> SubImage<I> {
@@ -352,6 +355,7 @@ impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubI
 }
 
 #[allow(deprecated)]
+#[old_impl_check]
 impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> GenericImage<P> for SubImage<'a, I> {
     fn dimensions(&self) -> (u32, u32) {
         (self.xstride, self.ystride)

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -109,9 +109,9 @@ mod tests {
     /// Test that images written into other images works
     fn test_image_in_image() {
         let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_fn(16, 16, box |&: _, _| {
+        let source = ImageBuffer::from_fn(16, 16, Box::new(|&: _, _| {
             Rgb([255u8, 0, 0])
-        });
+        }));
         overlay(&mut target, &source, 0, 0);
         assert!(*target.get_pixel(0, 0) == Rgb([255u8, 0, 0]));
         assert!(*target.get_pixel(15, 0) == Rgb([255u8, 0, 0]));
@@ -124,9 +124,9 @@ mod tests {
     /// Test that images written outside of a frame doesn't blow up
     fn test_image_in_image_outside_of_bounds() {
         let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_fn(32, 32, box |&: _, _| {
+        let source = ImageBuffer::from_fn(32, 32, Box::new(|&: _, _| {
             Rgb([255u8, 0, 0])
-        });
+        }));
         overlay(&mut target, &source, 1, 1);
         assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(1, 1) == Rgb([255u8, 0, 0]));

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -319,7 +319,7 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
     kernel: &[f32]) -> ImageBuffer<Vec<P>, P, T> {
 
     // The kernel's input positions relative to the current pixel.
-    let taps: &[(int, int)] = &[
+    let taps: &[(isize, isize)] = &[
         (-1, -1), ( 0, -1), ( 1, -1),
         (-1,  0), ( 0,  0), ( 1,  0),
         (-1,  1), ( 0,  1), ( 1,  1),
@@ -353,8 +353,8 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
             // Only a subtract and addition is needed for pixels after the first
             // in each row.
             for (&k, &(a, b)) in kernel.iter().zip(taps.iter()) {
-                let x0 = x as int + a;
-                let y0 = y as int + b;
+                let x0 = x as isize + a;
+                let y0 = y as isize + b;
 
                 let p = image.get_pixel(x0 as u32, y0 as u32);
 
@@ -405,23 +405,23 @@ pub fn resize<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>
 
     let mut method = match filter {
         FilterType::Nearest    =>   Filter {
-            kernel: box |&: x| box_kernel(x),
+            kernel: Box::new(|&: x| box_kernel(x)),
             support: 0.5
         },
         FilterType::Triangle   => Filter {
-            kernel: box |&: x| triangle_kernel(x),
+            kernel: Box::new(|&: x| triangle_kernel(x)),
             support: 1.0
         },
         FilterType::CatmullRom => Filter {
-            kernel: box |&: x| catmullrom_kernel(x),
+            kernel: Box::new(|&: x| catmullrom_kernel(x)),
             support: 2.0
         },
         FilterType::Gaussian   => Filter {
-            kernel: box |&: x| gaussian_kernel(x),
+            kernel: Box::new(|&: x| gaussian_kernel(x)),
             support: 3.0
         },
         FilterType::Lanczos3   => Filter {
-            kernel: box |&: x| lanczos3_kernel(x),
+            kernel: Box::new(|&: x| lanczos3_kernel(x)),
             support: 3.0
         },
 };
@@ -443,7 +443,7 @@ pub fn blur<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
     };
 
     let mut method = Filter {
-        kernel: box |&: x| gaussian(x, sigma),
+        kernel: Box::new(|&: x| gaussian(x, sigma)),
         support: 2.0 * sigma
     };
 

--- a/src/jpeg/transform.rs
+++ b/src/jpeg/transform.rs
@@ -80,7 +80,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
     // Pass 1: process rows.
     // Results are scaled by sqrt(8) compared to a true DCT
     // furthermore we scale the results by 2**PASS1_BITS
-    for y in range(0u, 8) {
+    for y in range(0us, 8) {
         let y0 = y * 8;
 
         // Even part
@@ -100,15 +100,15 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
         let t3 = samples[y0 + 3] as i32 - samples[y0 + 4] as i32;
 
         // Apply unsigned -> signed conversion
-        coeffs[y0 + 0] = (t10 + t11 - 8 * 128) << PASS1_BITS as uint;
-        coeffs[y0 + 4] = (t10 - t11) << PASS1_BITS as uint;
+        coeffs[y0 + 0] = (t10 + t11 - 8 * 128) << PASS1_BITS as usize;
+        coeffs[y0 + 4] = (t10 - t11) << PASS1_BITS as usize;
 
         let mut z1 = (t12 + t13) * FIX_0_541196100;
         // Add fudge factor here for final descale
-        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as uint;
+        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as usize;
 
-        coeffs[y0 + 2] = (z1 + t12 * FIX_0_765366865) >> (CONST_BITS - PASS1_BITS) as uint;
-        coeffs[y0 + 6] = (z1 - t13 * FIX_1_847759065) >> (CONST_BITS - PASS1_BITS) as uint;
+        coeffs[y0 + 2] = (z1 + t12 * FIX_0_765366865) >> (CONST_BITS - PASS1_BITS) as usize;
+        coeffs[y0 + 6] = (z1 - t13 * FIX_1_847759065) >> (CONST_BITS - PASS1_BITS) as usize;
 
         // Odd part
         let t12 = t0 + t2;
@@ -116,7 +116,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
 
         let mut z1 = (t12 + t13) * FIX_1_175875602;
         // Add fudge factor here for final descale
-        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as uint;
+        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as usize;
 
         let mut t12 = t12 * (-FIX_0_390180644);
         let mut t13 = t13 * (-FIX_1_961570560);
@@ -135,16 +135,16 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
         t1 += z1 + t13;
         t2 += z1 + t12;
 
-        coeffs[y0 + 1] = t0 >> (CONST_BITS - PASS1_BITS) as uint;
-        coeffs[y0 + 3] = t1 >> (CONST_BITS - PASS1_BITS) as uint;
-        coeffs[y0 + 5] = t2 >> (CONST_BITS - PASS1_BITS) as uint;
-        coeffs[y0 + 7] = t3 >> (CONST_BITS - PASS1_BITS) as uint;
+        coeffs[y0 + 1] = t0 >> (CONST_BITS - PASS1_BITS) as usize;
+        coeffs[y0 + 3] = t1 >> (CONST_BITS - PASS1_BITS) as usize;
+        coeffs[y0 + 5] = t2 >> (CONST_BITS - PASS1_BITS) as usize;
+        coeffs[y0 + 7] = t3 >> (CONST_BITS - PASS1_BITS) as usize;
     }
 
     // Pass 2: process columns
     // We remove the PASS1_BITS scaling but leave the results scaled up an
     // overall factor of 8
-    for x in range(0u, 8).rev() {
+    for x in range(0us, 8).rev() {
         // Even part
         let t0 = coeffs[x + 8 * 0] + coeffs[x + 8 * 7];
         let t1 = coeffs[x + 8 * 1] + coeffs[x + 8 * 6];
@@ -152,7 +152,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
         let t3 = coeffs[x + 8 * 3] + coeffs[x + 8 * 4];
 
         // Add fudge factor here for final descale
-        let t10 = t0 + t3 + (1 << (PASS1_BITS - 1) as uint);
+        let t10 = t0 + t3 + (1 << (PASS1_BITS - 1) as usize);
         let t12 = t0 - t3;
         let t11 = t1 + t2;
         let t13 = t1 - t2;
@@ -162,15 +162,15 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
         let t2 = coeffs[x + 8 * 2] - coeffs[x + 8 * 5];
         let t3 = coeffs[x + 8 * 3] - coeffs[x + 8 * 4];
 
-        coeffs[x + 8 * 0] = (t10 + t11) >> PASS1_BITS as uint;
-        coeffs[x + 8 * 4] = (t10 - t11) >> PASS1_BITS as uint;
+        coeffs[x + 8 * 0] = (t10 + t11) >> PASS1_BITS as usize;
+        coeffs[x + 8 * 4] = (t10 - t11) >> PASS1_BITS as usize;
 
         let mut z1 = (t12 + t13) * FIX_0_541196100;
         // Add fudge factor here for final descale
-        z1 += 1 << (CONST_BITS + PASS1_BITS - 1) as uint;
+        z1 += 1 << (CONST_BITS + PASS1_BITS - 1) as usize;
 
-        coeffs[x + 8 * 2] = (z1 + t12 * FIX_0_765366865) >> (CONST_BITS + PASS1_BITS) as uint;
-        coeffs[x + 8 * 6] = (z1 - t13 * FIX_1_847759065) >> (CONST_BITS + PASS1_BITS) as uint;
+        coeffs[x + 8 * 2] = (z1 + t12 * FIX_0_765366865) >> (CONST_BITS + PASS1_BITS) as usize;
+        coeffs[x + 8 * 6] = (z1 - t13 * FIX_1_847759065) >> (CONST_BITS + PASS1_BITS) as usize;
 
         // Odd part
         let t12 = t0 + t2;
@@ -178,7 +178,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
 
         let mut z1 = (t12 + t13) * FIX_1_175875602;
         // Add fudge factor here for final descale
-        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as uint;
+        z1 += 1 << (CONST_BITS - PASS1_BITS - 1) as usize;
 
         let mut t12 = t12 * (-FIX_0_390180644);
         let mut t13 = t13 * (-FIX_1_961570560);
@@ -197,21 +197,21 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
         t1 += z1 + t13;
         t2 += z1 + t12;
 
-        coeffs[x + 8 * 1] = t0 >> (CONST_BITS + PASS1_BITS) as uint;
-        coeffs[x + 8 * 3] = t1 >> (CONST_BITS + PASS1_BITS) as uint;
-        coeffs[x + 8 * 5] = t2 >> (CONST_BITS + PASS1_BITS) as uint;
-        coeffs[x + 8 * 7] = t3 >> (CONST_BITS + PASS1_BITS) as uint;
+        coeffs[x + 8 * 1] = t0 >> (CONST_BITS + PASS1_BITS) as usize;
+        coeffs[x + 8 * 3] = t1 >> (CONST_BITS + PASS1_BITS) as usize;
+        coeffs[x + 8 * 5] = t2 >> (CONST_BITS + PASS1_BITS) as usize;
+        coeffs[x + 8 * 7] = t3 >> (CONST_BITS + PASS1_BITS) as usize;
     }
 }
 
 pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
     let mut tmp = [0i32; 64];
 
-    for x in range(0u, 8).rev() {
+    for x in range(0us, 8).rev() {
         if coeffs[x + 8 * 1] == 0 && coeffs[x + 8 * 2] == 0 && coeffs[x + 8 * 3] == 0 &&
             coeffs[x + 8 * 4] == 0 && coeffs[x + 8 * 5] == 0 && coeffs[x + 8 * 6] == 0 &&
             coeffs[x + 8 * 7] == 0 {
-            let dcval = coeffs[x + 8 * 0] << PASS1_BITS as uint;
+            let dcval = coeffs[x + 8 * 0] << PASS1_BITS as usize;
 
             tmp[x + 8 * 0] = dcval;
             tmp[x + 8 * 1] = dcval;
@@ -235,10 +235,10 @@ pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
 
         let mut z2 = coeffs[x + 8 * 0];
         let mut z3 = coeffs[x + 8 * 4];
-        z2 <<= CONST_BITS as uint;
-        z3 <<= CONST_BITS as uint;
+        z2 <<= CONST_BITS as usize;
+        z3 <<= CONST_BITS as usize;
 
-        z2 += 1 << (CONST_BITS - PASS1_BITS - 1) as uint;
+        z2 += 1 << (CONST_BITS - PASS1_BITS - 1) as usize;
 
         let t0 = z2 + z3;
         let t1 = z2 - z3;
@@ -274,17 +274,17 @@ pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
         t1 += z1 + z3;
         t2 += z1 + z2;
 
-        tmp[x + 8 * 0] = (t10 + t3) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 7] = (t10 - t3) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 1] = (t11 + t2) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 6] = (t11 - t2) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 2] = (t12 + t1) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 5] = (t12 - t1) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 3] = (t13 + t0) >> (CONST_BITS - PASS1_BITS) as uint;
-        tmp[x + 8 * 4] = (t13 - t0) >> (CONST_BITS - PASS1_BITS) as uint;
+        tmp[x + 8 * 0] = (t10 + t3) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 7] = (t10 - t3) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 1] = (t11 + t2) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 6] = (t11 - t2) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 2] = (t12 + t1) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 5] = (t12 - t1) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 3] = (t13 + t0) >> (CONST_BITS - PASS1_BITS) as usize;
+        tmp[x + 8 * 4] = (t13 - t0) >> (CONST_BITS - PASS1_BITS) as usize;
     }
 
-    for y in range(0u, 8) {
+    for y in range(0us, 8) {
         let y0 = y * 8;
 
         let z2 = tmp[y0 + 2];
@@ -294,11 +294,11 @@ pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
         let t2 = z1 + z2 * FIX_0_765366865;
         let t3 = z1 - z3 * FIX_1_847759065;
 
-        let z2 = tmp[y0 + 0] + (1 << (PASS1_BITS + 2) as uint);
+        let z2 = tmp[y0 + 0] + (1 << (PASS1_BITS + 2) as usize);
         let z3 = tmp[y0 + 4];
 
-        let t0 = (z2 + z3) << CONST_BITS as uint;
-        let t1 = (z2 - z3) << CONST_BITS as uint;
+        let t0 = (z2 + z3) << CONST_BITS as usize;
+        let t1 = (z2 - z3) << CONST_BITS as usize;
 
         let t10 = t0 + t2;
         let t13 = t0 - t2;
@@ -331,28 +331,28 @@ pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
         t1 += z1 + z3;
         t2 += z1 + z2;
 
-        let a = (t10 + t3) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t10 + t3) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 0] = level_shift_up(a);
 
-        let a = (t10 - t3) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t10 - t3) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 7] = level_shift_up(a);
 
-        let a = (t11 + t2) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t11 + t2) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 1] = level_shift_up(a);
 
-        let a = (t11 - t2) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t11 - t2) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 6] = level_shift_up(a);
 
-        let a = (t12 + t1) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t12 + t1) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 2] = level_shift_up(a);
 
-        let a = (t12 - t1) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t12 - t1) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 5] = level_shift_up(a);
 
-        let a = (t13 + t0) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t13 + t0) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 3] = level_shift_up(a);
 
-        let a = (t13 - t0) >> (CONST_BITS + PASS1_BITS + 3) as uint;
+        let a = (t13 - t0) >> (CONST_BITS + PASS1_BITS + 3) as usize;
         samples[y0 + 4] = level_shift_up(a);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(unused_typecasts)]
 #![deny(missing_copy_implementations)]
 // necessary for Primitive trait
-#![feature(old_orphan_check)]
+#![feature(old_orphan_check, old_impl_check)]
 
 extern crate flate;
 extern crate num;

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -29,7 +29,7 @@ fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
     }
 }
 
-pub fn unfilter(filter: FilterType, bpp: uint, previous: &[u8], current: &mut [u8]) {
+pub fn unfilter(filter: FilterType, bpp: usize, previous: &[u8], current: &mut [u8]) {
     let len = current.len();
 
     match filter {
@@ -65,7 +65,7 @@ pub fn unfilter(filter: FilterType, bpp: uint, previous: &[u8], current: &mut [u
     }
 }
 
-pub fn filter(method: FilterType, bpp: uint, previous: &[u8], current: &mut [u8]) {
+pub fn filter(method: FilterType, bpp: usize, previous: &[u8], current: &mut [u8]) {
     let len  = current.len();
     let orig: Vec<u8> = range(0, len).map(| i | current[i]).collect();
 

--- a/src/png/hash.rs
+++ b/src/png/hash.rs
@@ -116,7 +116,7 @@ impl Crc32 {
             let a = (self.crc ^ byte as u32) & 0xFF;
             let b = self.crc >> 8;
 
-            self.crc = CRC_TABLE[a as uint] ^ b;
+            self.crc = CRC_TABLE[a as usize] ^ b;
         }
     }
 

--- a/src/png/zlib.rs
+++ b/src/png/zlib.rs
@@ -68,7 +68,7 @@ impl<R: Reader> ZlibDecoder<R> {
 }
 
 impl<R: Reader> Reader for ZlibDecoder<R> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         match self.state {
             ZlibState::CompressedData => {
                 match self.inflate.read(buf) {

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -56,7 +56,7 @@ impl<W: Writer> PPMEncoder<W> {
         assert!(buf.len() > 0);
         match pixel_type {
             Grey(8) => {
-                for i in range(0, (width * height) as uint) {
+                for i in range(0, (width * height) as usize) {
                     let _ = try!(self.w.write_u8(buf[i]));
                     let _ = try!(self.w.write_u8(buf[i]));
                     let _ = try!(self.w.write_u8(buf[i]));
@@ -76,7 +76,7 @@ impl<W: Writer> PPMEncoder<W> {
                 }
             }
 
-            a => panic!(format!("not implemented: {}", a))
+            a => panic!(format!("not implemented: {:?}", a))
         }
 
         Ok(())
@@ -87,10 +87,10 @@ fn max_pixel_value(pixel_type: color::ColorType) -> u16 {
     use std::num::Int;
 
     match pixel_type {
-        Grey(n)    => 2u16.pow(n as uint) - 1,
-        RGB(n)     => 2u16.pow(n as uint) - 1,
-        Palette(n) => 2u16.pow(n as uint) - 1,
-        GreyA(n)   => 2u16.pow(n as uint) - 1,
-        RGBA(n)    => 2u16.pow(n as uint) - 1
+        Grey(n)    => 2u16.pow(n as usize) - 1,
+        RGB(n)     => 2u16.pow(n as usize) - 1,
+        Palette(n) => 2u16.pow(n as usize) - 1,
+        GreyA(n)   => 2u16.pow(n as usize) - 1,
+        RGBA(n)    => 2u16.pow(n as usize) - 1
     }
 }

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -66,7 +66,7 @@ impl Value {
         match self {
             Value::Unsigned(val) => Ok(val),
             val => Err(::image::ImageError::FormatError(format!(
-                "Expected unsigned integer, {} found.", val
+                "Expected unsigned integer, {:?} found.", val
             )))
         }
     }
@@ -93,7 +93,7 @@ pub struct Entry {
 
 impl ::std::fmt::Show for Entry {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        fmt.write_str(format!("Entry {{ type: {}, count: {}, offset: {} }}",
+        fmt.write_str(format!("Entry {{ type: {:?}, count: {:?}, offset: {:?} }}",
             self.type_,
             self.count,
             self.offset.as_slice()
@@ -128,7 +128,7 @@ impl Entry {
             (Type::SHORT, 1) => Ok(Value::Unsigned(try!(self.r(bo).read_u16()) as u32)),
             (Type::LONG, 1) => Ok(Value::Unsigned(try!(self.r(bo).read_u32()))),
             (Type::LONG, n) => {
-                let mut v = Vec::with_capacity(n as uint);
+                let mut v = Vec::with_capacity(n as usize);
                 try!(decoder.goto_offset(try!(self.r(bo).read_u32())));
                 for _ in range(0, n) {
                     v.push(Value::Unsigned(try!(decoder.read_long())))

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -28,12 +28,12 @@ macro_rules! zero_impl {
         }
     }
 }
-zero_impl!(uint, 0u);
+zero_impl!(usize, 0us);
 zero_impl!(u8,   0u8);
 zero_impl!(u16,  0u16);
 zero_impl!(u32,  0u32);
 zero_impl!(u64,  0u64);
-zero_impl!(int, 0i);
+zero_impl!(isize, 0is);
 zero_impl!(i8,  0i8);
 zero_impl!(i16, 0i16);
 zero_impl!(i32, 0i32);
@@ -48,8 +48,8 @@ pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone {
     fn max_value() -> Self;
 }
 
-impl Primitive for uint {
-    fn max_value() -> uint { Int::max_value() }
+impl Primitive for usize {
+    fn max_value() -> usize { Int::max_value() }
 }
 impl Primitive for u8 {
     fn max_value() -> u8 { Int::max_value() }
@@ -63,8 +63,8 @@ impl Primitive for u32 {
 impl Primitive for u64 {
     fn max_value() -> u64 { Int::max_value() }
 }
-impl Primitive for int {
-    fn max_value() -> int { Int::max_value() }
+impl Primitive for isize {
+    fn max_value() -> isize { Int::max_value() }
 }
 impl Primitive for i8 {
     fn max_value() -> i8 { Int::max_value() }
@@ -100,12 +100,12 @@ macro_rules! one_impl {
         }
     }
 }
-one_impl!(uint, 1u);
+one_impl!(usize, 1us);
 one_impl!(u8,  1u8);
 one_impl!(u16, 1u16);
 one_impl!(u32, 1u32);
 one_impl!(u64, 1u64);
-one_impl!(int, 1i);
+one_impl!(isize, 1is);
 one_impl!(i8,  1i8);
 one_impl!(i16, 1i16);
 one_impl!(i32, 1i32);

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -99,10 +99,10 @@ impl<R: Reader> ImageDecoder for WebpDecoder<R> {
         Ok(color::ColorType::Grey(8))
     }
 
-    fn row_len(&mut self) -> ImageResult<uint> {
+    fn row_len(&mut self) -> ImageResult<usize> {
         let _ = try!(self.read_metadata());
 
-        Ok(self.frame.width as uint)
+        Ok(self.frame.width as usize)
     }
 
     fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
@@ -114,8 +114,8 @@ impl<R: Reader> ImageDecoder for WebpDecoder<R> {
 
         let rlen  = buf.len();
         let slice = self.frame.ybuf.slice(
-            self.decoded_rows as uint * rlen,
-            self.decoded_rows as uint * rlen + rlen
+            self.decoded_rows as usize * rlen,
+            self.decoded_rows as usize * rlen + rlen
         );
 
         slice::bytes::copy_memory(buf, slice);

--- a/src/webp/transform.rs
+++ b/src/webp/transform.rs
@@ -4,7 +4,7 @@ static CONST2:
 i32 = 35468;
 
 pub fn idct4x4(block: &mut [i32]) {
-    for i in range(0u, 4) {
+    for i in range(0us, 4) {
         let a1 = block[0 + i] + block[8 + i];
         let b1 = block[0 + i] - block[8 + i];
 
@@ -22,7 +22,7 @@ pub fn idct4x4(block: &mut [i32]) {
         block[4 * 2 + i] = b1 - c1;
     }
 
-    for i in range(0u, 4) {
+    for i in range(0us, 4) {
         let a1 = block[4 * i + 0] + block[4 * i + 2];
         let b1 = block[4 * i + 0] - block[4 * i + 2];
 
@@ -43,7 +43,7 @@ pub fn idct4x4(block: &mut [i32]) {
 
 // 14.3
 pub fn iwht4x4(block: &mut [i32]) {
-    for i in range(0u, 4) {
+    for i in range(0us, 4) {
         let a1 = block[0 + i] + block[12 + i];
         let b1 = block[4 + i] + block[8  + i];
         let c1 = block[4 + i] - block[8  + i];
@@ -55,7 +55,7 @@ pub fn iwht4x4(block: &mut [i32]) {
         block[12 + i] = d1 - c1;
     }
 
-    for i in range(0u, 4) {
+    for i in range(0us, 4) {
         let a1 = block[4 * i + 0] + block[4 * i + 3];
         let b1 = block[4 * i + 1] + block[4 * i + 2];
         let c1 = block[4 * i + 1] - block[4 * i + 2];


### PR DESCRIPTION
Mostly around macro syntax and the {:?} format specifier. Also had to add old_impl_check to some of the impls until that can be reviewed in more detail.
Also did a sweeping change from int/uint to isize/usize. No consideration was given to whether fixed sized integers would be more appropriate in some contexts; that would take a more thorough audit. This is just a blanket change to the new names.