### PR TITLE
Update range syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ fn main() {
         //Create a new ImgBuf with width: imgx and height: imgy
         let mut imbuf = image::ImageBuffer::new(imgx, imgy);
 
-        for y in range(0, imgy) {
+        for y in (0..imgy) {
                 let cy = y as f32 * scaley - 2.0;
 
-                for x in range(0, imgx) {
+                for x in (0..imgx) {
                         let cx = x as f32 * scalex - 2.0;
 
                         let mut z = Complex::new(cx, cy);
@@ -244,7 +244,7 @@ fn main() {
 
                         let mut i = 0;
 
-                        for t in range(0, max_iterations) {
+                        for t in (0..max_iterations) {
                                 if z.norm() > 2.0 {
                                         break
                                 }

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -164,7 +164,7 @@ impl<R: Reader> GIFDecoder<R> {
     fn skip_extension(&mut self) -> ImageResult<()> {
         let mut size = try!(self.r.read_u8());
         while size != 0 {
-            for _ in range(0, size) {
+            for _ in (0..size) {
                 let _ = try!(self.r.read_u8());
             }
             size = try!(self.r.read_u8());

--- a/src/gif/lzw.rs
+++ b/src/gif/lzw.rs
@@ -31,7 +31,7 @@ impl DecodingDict {
     /// Resets the dictionary
     fn reset(&mut self) {
         self.table.clear();
-        for i in range(0, (1u16 << self.min_size as usize)) {
+        for i in (0..(1u16 << self.min_size as usize)) {
             self.table.push((None, i as u8));
         }
     }

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -12,8 +12,8 @@ pub fn rotate90<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y);
             out.put_pixel(height - 1 - y, x, p);
         }
@@ -27,8 +27,8 @@ pub fn rotate180<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y);
             out.put_pixel(width - 1 - x, height - 1 - y, p);
         }
@@ -42,8 +42,8 @@ pub fn rotate270<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y);
             out.put_pixel(y, width - 1 - x, p);
         }
@@ -57,8 +57,8 @@ pub fn flip_horizontal<P: Primitive + 'static, T: Pixel<P> + 'static, I: Generic
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y);
             out.put_pixel(width - 1 - x, y, p);
         }
@@ -72,8 +72,8 @@ pub fn flip_vertical<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y);
             out.put_pixel(x, height - 1 - y, p);
         }

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -29,8 +29,8 @@ pub fn grayscale<P: Primitive + Default + 'static, T: Pixel<P> + 'static, I: Gen
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let p = image.get_pixel(x, y).to_luma();
             out.put_pixel(x, y, p);
         }
@@ -44,8 +44,8 @@ pub fn grayscale<P: Primitive + Default + 'static, T: Pixel<P> + 'static, I: Gen
 pub fn invert<P: Primitive, T: Pixel<P>, I: GenericImage<T>>(image: &mut I) {
     let (width, height) = image.dimensions();
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let mut p = image.get_pixel(x, y);
             p.invert();
 
@@ -69,8 +69,8 @@ pub fn contrast<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
 
     let percent = ((100.0 + contrast) / 100.0).powi(2);
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let f = image.get_pixel(x, y).map(|&: b| {
                 let c = cast::<P, f32>(b).unwrap();
 
@@ -100,8 +100,8 @@ pub fn brighten<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
     let max: P = Primitive::max_value();
     let max = cast::<P, i32>(max).unwrap();
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let e = image.get_pixel(x, y).map_with_alpha(|&:b| {
                 let c = cast::<P, i32>(b).unwrap();
                 let d = clamp(c + value, 0, max);

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -89,8 +89,8 @@ pub fn overlay<P: Primitive, T: Pixel<P>, I: GenericImage<T>>(
         top_height
     };
 
-    for top_y in range(0, range_height) {
-        for top_x in range(0, range_width) {
+    for top_y in (0..range_height) {
+        for top_x in (0..range_width) {
             let p = top.get_pixel(top_x, top_y);
             bottom.get_pixel_mut(x + top_x, y + top_y).blend(&p);
         }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -151,7 +151,7 @@ fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(new_width, height);
 
-    for y in range(0, height) {
+    for y in (0..height) {
         let max: P = Primitive::max_value();
         let max = cast::<P, f32>(max).unwrap();
 
@@ -166,7 +166,7 @@ fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
 
         let filter_radius = (filter.support * filter_scale).ceil();
 
-        for outx in range(0, new_width) {
+        for outx in (0..new_width) {
             let inputx = (outx as f32 + 0.5) * ratio;
 
             let left  = (inputx - filter_radius).ceil() as u32;
@@ -182,7 +182,7 @@ fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
             let mut t3 = 0.0;
             let mut t4 = 0.0;
 
-            for i in range(left, right + 1) {
+            for i in (left..right + 1) {
                 let w = (filter.kernel)((i as f32 - inputx) / filter_scale);
                 sum += w;
 
@@ -238,7 +238,7 @@ fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImag
     let mut out = ImageBuffer::new(width, new_height);
 
 
-    for x in range(0, width) {
+    for x in (0..width) {
         let max: P = Primitive::max_value();
         let max = cast::<P, f32>(max).unwrap();
 
@@ -253,7 +253,7 @@ fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImag
 
         let filter_radius = (filter.support * filter_scale).ceil();
 
-        for outy in range(0, new_height) {
+        for outy in (0..new_height) {
             let inputy = (outy as f32 + 0.5) * ratio;
 
             let left  = (inputy - filter_radius).ceil() as u32;
@@ -269,7 +269,7 @@ fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImag
             let mut t3 = 0.0;
             let mut t4 = 0.0;
 
-            for i in range(left, right + 1) {
+            for i in (left..right + 1) {
                 let w = (filter.kernel)((i as f32 - inputy) / filter_scale);
                 sum += w;
 
@@ -342,8 +342,8 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
         sum
     };
 
-    for y in range(1, height - 1) {
-        for x in range(1, width - 1) {
+    for y in (1..height - 1) {
+        for x in (1..width - 1) {
             let mut t1 = 0.0;
             let mut t2 = 0.0;
             let mut t3 = 0.0;
@@ -469,8 +469,8 @@ pub fn unsharpen<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<
     let max: A = Primitive::max_value();
     let (width, height) = image.dimensions();
 
-    for y in range(0, height) {
-        for x in range(0, width) {
+    for y in (0..height) {
+        for x in (0..width) {
             let a = image.get_pixel(x, y);
             let b = tmp.get_pixel_mut(x, y);
 

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -195,7 +195,7 @@ impl<R: Reader>JPEGDecoder<R> {
         for id in tmp.iter() {
             let mut c = self.components.get(&(*id as usize)).unwrap().clone();
 
-            for _ in range(0, c.h * c.v) {
+            for _ in (0..c.h * c.v) {
                 let pred  = try!(self.decode_block(i, c.dc_table, c.dc_pred, c.ac_table, c.tq));
                 c.dc_pred = pred;
                 i += 1;
@@ -330,7 +330,7 @@ impl<R: Reader>JPEGDecoder<R> {
     fn read_frame_components(&mut self, n: u8) -> ImageResult<()> {
         let mut blocks_per_mcu = 0;
 
-        for _ in range(0, n) {
+        for _ in (0..n) {
             let id = try!(self.r.read_u8());
             let hv = try!(self.r.read_u8());
             let tq = try!(self.r.read_u8());
@@ -385,7 +385,7 @@ impl<R: Reader>JPEGDecoder<R> {
 
         self.scan_components = Vec::new();
 
-        for _ in range(0, num_scan_components as usize) {
+        for _ in (0..num_scan_components as usize) {
             let id = try!(self.r.read_u8());
             let tables = try!(self.r.read_u8());
 
@@ -423,7 +423,7 @@ impl<R: Reader>JPEGDecoder<R> {
 
             let slice = self.qtables.slice_mut(64 * tq as usize, 64 * tq as usize + 64);
 
-            for i in range(0us, 64) {
+            for i in (0us..64) {
                 slice[i] = try!(self.r.read_u8());
             }
 
@@ -610,8 +610,8 @@ impl<R: Reader> ImageDecoder for JPEGDecoder<R> {
 
 fn upsample_mcu(out: &mut [u8], xoffset: usize, width: usize, bpp: usize, mcu: &[u8], h: u8, v: u8) {
     if mcu.len() == 64 {
-        for y in range(0us, 8) {
-            for x in range(0us, 8) {
+        for y in (0us..8) {
+            for x in (0us..8) {
                 out[xoffset + x + (y * width)] = mcu[x + y * 8]
             }
         }
@@ -624,14 +624,14 @@ fn upsample_mcu(out: &mut [u8], xoffset: usize, width: usize, bpp: usize, mcu: &
 
         let mut k = 0;
 
-        for by in range(0, v as usize) {
+        for by in (0..v as usize) {
             let y0 = by * 8;
 
-            for bx in range(0, h as usize) {
+            for bx in (0..h as usize) {
                 let x0 = xoffset + bx * 8 * bpp;
 
-                for y in range(0us, 8) {
-                    for x in range(0us, 8) {
+                for y in (0us..8) {
+                    for x in (0us..8) {
                         let (a, b, c) = (y_blocks[k * 64 + x + y * 8], cb[x + y * 8], cr[x + y * 8]);
                         let (r, g, b) = ycbcr_to_rgb(a , b , c );
 

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -370,7 +370,7 @@ impl<W: Writer> JPEGEncoder<W> {
                 transform::fdct(yblock.as_slice(), &mut dct_yblock);
 
                 // Quantization
-                for i in range(0us, 64) {
+                for i in (0us..64) {
                     dct_yblock[i]   = ((dct_yblock[i] / 8)   as f32 / self.tables.slice_to(64)[i] as f32).round() as i32;
                 }
 
@@ -409,7 +409,7 @@ impl<W: Writer> JPEGEncoder<W> {
                 transform::fdct(cr_block.as_slice(), &mut dct_cr_block);
 
                 // Quantization
-                for i in range(0us, 64) {
+                for i in (0us..64) {
                     dct_yblock[i]   = ((dct_yblock[i] / 8)   as f32 / self.tables.slice_to(64)[i] as f32).round() as i32;
                     dct_cb_block[i] = ((dct_cb_block[i] / 8) as f32 / self.tables.slice_from(64)[i] as f32).round() as i32;
                     dct_cr_block[i] = ((dct_cr_block[i] / 8) as f32 / self.tables.slice_from(64)[i] as f32).round() as i32;
@@ -527,7 +527,7 @@ fn build_quantization_segment(precision: u8,
     let pqtq = (p << 4) | identifier;
     let _    = m.write_u8(pqtq);
 
-    for i in range(0us, 64) {
+    for i in (0us..64) {
         let _ = m.write_u8(qtable[UNZIGZAG[i] as usize]);
     }
 
@@ -583,10 +583,10 @@ fn copy_blocks_ycbcr(source: &[u8],
                      cbb: &mut [u8; 64],
                      crb: &mut [u8; 64]) {
 
-    for y in range(0us, 8) {
+    for y in (0us..8) {
         let ystride = (y0 + y) * bpp * width;
 
-        for x in range(0us, 8) {
+        for x in (0us..8) {
             let xstride = x0 * bpp + x * bpp;
 
             let r = value_at(source, ystride + xstride + 0);
@@ -609,10 +609,10 @@ fn copy_blocks_grey(source: &[u8],
                     bpp: usize,
                     gb: &mut [u8; 64]) {
 
-    for y in range(0us, 8) {
+    for y in (0us..8) {
         let ystride = (y0 + y) * bpp * width;
 
-        for x in range(0us, 8) {
+        for x in (0us..8) {
             let xstride = x0 * bpp + x * bpp;
             gb[y * 8 + x] = value_at(source, ystride + xstride + 1);
         }

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -83,7 +83,7 @@ impl HuffDecoder {
         } else {
             let mut code = 0us;
 
-            for i in range(0us, 16) {
+            for i in (0us..16) {
                 let b = try!(self.read_bit(r));
                 code |= b as usize;
 
@@ -116,7 +116,7 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
     // Annex C.2
     // Figure C.1
     // Generate table of individual code lengths
-    for i in range(0us, 16) {
+    for i in (0us..16) {
         j = 0;
 
         while j < bits[i] {
@@ -176,7 +176,7 @@ pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
     // Figure F.15
     let mut j = 0;
 
-    for i in range(0us, 16) {
+    for i in (0us..16) {
         if bits[i] != 0 {
             valptr.as_mut_slice()[i] = j;
             mincode.as_mut_slice()[i] = huffcode[j as usize] as isize;
@@ -194,7 +194,7 @@ pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
 
         let r = 8 - huffsize[i] as usize;
 
-        for j in range(0us, 1 << r) {
+        for j in (0us..1 << r) {
             let index = (huffcode[i] << r) + j as u16;
             lut.as_mut_slice()[index as usize] = (*v, huffsize[i]);
         }

--- a/src/jpeg/transform.rs
+++ b/src/jpeg/transform.rs
@@ -80,7 +80,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
     // Pass 1: process rows.
     // Results are scaled by sqrt(8) compared to a true DCT
     // furthermore we scale the results by 2**PASS1_BITS
-    for y in range(0us, 8) {
+    for y in (0us..8) {
         let y0 = y * 8;
 
         // Even part
@@ -144,7 +144,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
     // Pass 2: process columns
     // We remove the PASS1_BITS scaling but leave the results scaled up an
     // overall factor of 8
-    for x in range(0us, 8).rev() {
+    for x in (0us..8).rev() {
         // Even part
         let t0 = coeffs[x + 8 * 0] + coeffs[x + 8 * 7];
         let t1 = coeffs[x + 8 * 1] + coeffs[x + 8 * 6];
@@ -207,7 +207,7 @@ pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
 pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
     let mut tmp = [0i32; 64];
 
-    for x in range(0us, 8).rev() {
+    for x in (0us..8).rev() {
         if coeffs[x + 8 * 1] == 0 && coeffs[x + 8 * 2] == 0 && coeffs[x + 8 * 3] == 0 &&
             coeffs[x + 8 * 4] == 0 && coeffs[x + 8 * 5] == 0 && coeffs[x + 8 * 6] == 0 &&
             coeffs[x + 8 * 7] == 0 {
@@ -284,7 +284,7 @@ pub fn idct(coeffs: &[i32], samples: &mut [u8]) {
         tmp[x + 8 * 4] = (t13 - t0) >> (CONST_BITS - PASS1_BITS) as usize;
     }
 
-    for y in range(0us, 8) {
+    for y in (0us..8) {
         let y0 = y * 8;
 
         let z2 = tmp[y0 + 2];

--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -138,7 +138,7 @@ impl<R: Reader> Inflater<R> {
 
         let mut code_lengths: Vec<u8> = repeat(0u8).take(CODEORDER.len()).collect();
 
-        for i in range(0, hclen as usize) {
+        for i in (0..hclen as usize) {
             let length = try!(self.h.receive(3));
             code_lengths.as_mut_slice()[CODEORDER[i] as usize] = length as u8;
         }
@@ -159,7 +159,7 @@ impl<R: Reader> Inflater<R> {
                 16 => {
                     let repeat = 3 + try!(self.h.receive(2));
 
-                    for _ in range(0, repeat) {
+                    for _ in (0..repeat) {
                         all_lengths.as_mut_slice()[i as usize] = all_lengths[i as usize - 1];
                         i += 1;
                     }
@@ -243,7 +243,7 @@ impl<R: Reader> Inflater<R> {
                     let distance = DISTANCES[distance as usize] + extra;
 
                     let len = self.buf.len();
-                    for i in range(0, length) {
+                    for i in (0..length) {
                         let s = self.buf[len - distance as usize + i as usize];
                         self.buf.push(s);
                     }
@@ -272,7 +272,7 @@ impl<R: Reader> Reader for Inflater<R> {
         }
 
         let n = cmp::min(buf.len(), self.buf.len() - self.pos as usize);
-        for i in range(0us, n) {
+        for i in (0us..n) {
             buf.as_mut_slice()[i] = self.buf[self.pos as usize + i];
         }
 
@@ -306,7 +306,7 @@ fn table_from_lengths(lengths: &[u8]) -> Vec<TableElement> {
     let max_overflow = max_len - TABLESIZE;
     bl_count.as_mut_slice()[0] = 0;
 
-    for bits in range(1us, 16) {
+    for bits in (1us..16) {
         code = (code + bl_count[bits - 1] as u16) << 1;
         next_code.as_mut_slice()[bits] = code;
     }
@@ -324,7 +324,7 @@ fn table_from_lengths(lengths: &[u8]) -> Vec<TableElement> {
         if len <= TABLESIZE {
             let r = TABLESIZE - len;
 
-            for j in range(0u16, 1 << r as usize) {
+            for j in (0u16..1 << r as usize) {
                 let index = (j << len as usize) + code;
                 lut.as_mut_slice()[index as usize] = TableElement::Symbol(i as u16, len);
             }
@@ -341,7 +341,7 @@ fn table_from_lengths(lengths: &[u8]) -> Vec<TableElement> {
             let code = code >> TABLESIZE as usize;
             let r = max_len - len;
 
-            for j in range(0u16, 1 << r as usize) {
+            for j in (0u16..1 << r as usize) {
                 let k = (j << (len - TABLESIZE) as usize) + code;
                 let s = TableElement::Symbol(i as u16, len - TABLESIZE);
 

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -35,30 +35,30 @@ pub fn unfilter(filter: FilterType, bpp: usize, previous: &[u8], current: &mut [
     match filter {
         FilterType::NoFilter => (),
         FilterType::Sub => {
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] += current[i - bpp];
             }
         }
         FilterType::Up => {
-            for i in range(0, len) {
+            for i in (0..len) {
                 current[i] += previous[i];
             }
         }
         FilterType::Avg => {
-            for i in range(0, bpp) {
+            for i in (0..bpp) {
                 current[i] += previous[i] / 2;
             }
 
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] += ((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8;
             }
         }
         FilterType::Paeth => {
-            for i in range(0, bpp) {
+            for i in (0..bpp) {
                 current[i] += filter_paeth(0, previous[i], 0);
             }
 
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] += filter_paeth(current[i - bpp], previous[i], previous[i - bpp]);
             }
         }
@@ -72,30 +72,30 @@ pub fn filter(method: FilterType, bpp: usize, previous: &[u8], current: &mut [u8
     match method {
         FilterType::NoFilter => (),
         FilterType::Sub      => {
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] = orig[i] - orig[i - bpp];
             }
         }
         FilterType::Up       => {
-            for i in range(0, len) {
+            for i in (0..len) {
                 current[i] = orig[i] - previous[i];
             }
         }
         FilterType::Avg  => {
-            for i in range(0, bpp) {
+            for i in (0..bpp) {
                 current[i] = orig[i] - previous[i] / 2;
             }
 
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] = orig[i] - ((orig[i - bpp] as i16 + previous[i] as i16) / 2) as u8;
             }
         }
         FilterType::Paeth    => {
-            for i in range(0, bpp) {
+            for i in (0..bpp) {
                 current[i] = orig[i] - filter_paeth(0, previous[i], 0);
             }
 
-            for i in range(bpp, len) {
+            for i in (bpp..len) {
                 current[i] = orig[i] - filter_paeth(orig[i - bpp], previous[i], previous[i - bpp]);
             }
         }

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -56,7 +56,7 @@ impl<W: Writer> PPMEncoder<W> {
         assert!(buf.len() > 0);
         match pixel_type {
             Grey(8) => {
-                for i in range(0, (width * height) as usize) {
+                for i in (0..(width * height) as usize) {
                     let _ = try!(self.w.write_u8(buf[i]));
                     let _ = try!(self.w.write_u8(buf[i]));
                     let _ = try!(self.w.write_u8(buf[i]));

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -328,7 +328,7 @@ impl<R: Reader + Seek> TGADecoder<R> {
                 // high bit set, so we will repeat the data
                 let repeat_count = ((run_packet & !0x80) + 1) as usize;
                 let data = try!(self.r.read_exact(self.bytes_per_pixel));
-                for _ in range(0us, repeat_count) {
+                for _ in (0us..repeat_count) {
                     pixel_data.push_all(data.as_slice());
                 }
                 num_read += repeat_count;

--- a/src/tiff/decoder.rs
+++ b/src/tiff/decoder.rs
@@ -282,7 +282,7 @@ impl<R: Reader + Seek> TIFFDecoder<R> {
             ),
             Some(offset) => try!(self.goto_offset(offset))
         }
-        for _ in range(0, try!(self.read_short())) {
+        for _ in (0..try!(self.read_short())) {
             let (tag, entry) = match try!(self.read_entry()) {
                 Some(val) => val,
                 None => continue // Unknown data type in tag, skip

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -130,7 +130,7 @@ impl Entry {
             (Type::LONG, n) => {
                 let mut v = Vec::with_capacity(n as usize);
                 try!(decoder.goto_offset(try!(self.r(bo).read_u32())));
-                for _ in range(0, n) {
+                for _ in (0..n) {
                     v.push(Value::Unsigned(try!(decoder.read_long())))
                 }
                 Ok(Value::List(v))

--- a/src/webp/transform.rs
+++ b/src/webp/transform.rs
@@ -4,7 +4,7 @@ static CONST2:
 i32 = 35468;
 
 pub fn idct4x4(block: &mut [i32]) {
-    for i in range(0us, 4) {
+    for i in (0us..4) {
         let a1 = block[0 + i] + block[8 + i];
         let b1 = block[0 + i] - block[8 + i];
 
@@ -22,7 +22,7 @@ pub fn idct4x4(block: &mut [i32]) {
         block[4 * 2 + i] = b1 - c1;
     }
 
-    for i in range(0us, 4) {
+    for i in (0us..4) {
         let a1 = block[4 * i + 0] + block[4 * i + 2];
         let b1 = block[4 * i + 0] - block[4 * i + 2];
 
@@ -43,7 +43,7 @@ pub fn idct4x4(block: &mut [i32]) {
 
 // 14.3
 pub fn iwht4x4(block: &mut [i32]) {
-    for i in range(0us, 4) {
+    for i in (0us..4) {
         let a1 = block[0 + i] + block[12 + i];
         let b1 = block[4 + i] + block[8  + i];
         let c1 = block[4 + i] - block[8  + i];
@@ -55,7 +55,7 @@ pub fn iwht4x4(block: &mut [i32]) {
         block[12 + i] = d1 - c1;
     }
 
-    for i in range(0us, 4) {
+    for i in (0us..4) {
         let a1 = block[4 * i + 0] + block[4 * i + 3];
         let b1 = block[4 * i + 1] + block[4 * i + 2];
         let c1 = block[4 * i + 1] - block[4 * i + 2];

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -643,7 +643,7 @@ impl BoolReader {
         self.buf = buf;
         self.value = 0;
 
-        for _ in range(0us, 2) {
+        for _ in (0us..2) {
             self.value = (self.value << 8) | self.buf[self.index] as u32;
             self.index += 1;
         }
@@ -873,10 +873,10 @@ impl<R: Reader> VP8Decoder<R> {
 }
 
     fn update_token_probabilities(&mut self) {
-        for i in range(0us, 4) {
-            for j in range(0us, 8) {
-                for k in range(0us, 3) {
-                    for t in range(0us, NUM_DCT_TOKENS - 1) {
+        for i in (0us..4) {
+            for j in (0us..8) {
+                for k in (0us..3) {
+                    for t in (0us..NUM_DCT_TOKENS - 1) {
                         let prob = COEFF_UPDATE_PROBS[i][j][k][t];
                         if self.b.read_bool(prob) != 0 {
                             let v = self.b.read_literal(8);
@@ -924,7 +924,7 @@ impl<R: Reader> VP8Decoder<R> {
                         else { 0 };
 
         let n = if self.segments_enabled { MAX_SEGMENTS } else { 1 };
-        for i in range(0us, n) {
+        for i in (0us..n) {
             let base = if !self.segment[i].delta_values { self.segment[i].quantizer_level as i16 }
                     else { self.segment[i].quantizer_level as i16 + yac_abs as i16} as i32;
 
@@ -949,7 +949,7 @@ impl<R: Reader> VP8Decoder<R> {
 
     fn read_loop_filter_adjustments(&mut self) {
         if self.b.read_flag() {
-            for _i in range(0us, 4) {
+            for _i in (0us..4) {
                 let ref_frame_delta_update_flag = self.b.read_flag();
 
                 let _delta = if ref_frame_delta_update_flag {
@@ -959,7 +959,7 @@ impl<R: Reader> VP8Decoder<R> {
                 };
             }
 
-            for _i in range(0us, 4) {
+            for _i in (0us..4) {
                 let mb_mode_delta_update_flag = self.b.read_flag();
 
                 let _delta = if mb_mode_delta_update_flag {
@@ -979,11 +979,11 @@ impl<R: Reader> VP8Decoder<R> {
         if update_segment_feature_data {
             let segment_feature_mode = self.b.read_flag();
 
-            for i in range(0us, MAX_SEGMENTS) {
+            for i in (0us..MAX_SEGMENTS) {
                 self.segment[i].delta_values = !segment_feature_mode;
             }
 
-            for i in range(0us, MAX_SEGMENTS) {
+            for i in (0us..MAX_SEGMENTS) {
                 let update = self.b.read_flag();
 
                 self.segment[i].quantizer_level = if update {
@@ -993,7 +993,7 @@ impl<R: Reader> VP8Decoder<R> {
                 } as i8;
             }
 
-            for i in range(0us, MAX_SEGMENTS) {
+            for i in (0us..MAX_SEGMENTS) {
                 let update = self.b.read_flag();
 
                 self.segment[i].loopfilter_level = if update {
@@ -1005,7 +1005,7 @@ impl<R: Reader> VP8Decoder<R> {
         }
 
         if self.segments_update_map {
-            for i in range(0us, 3) {
+            for i in (0us..3) {
                 let update = self.b.read_flag();
 
                 self.segment_tree_probs[i] = if update {
@@ -1141,8 +1141,8 @@ impl<R: Reader> VP8Decoder<R> {
                                                  &KEYFRAME_YMODE_PROBS, 0);
 
             if mb.luma_mode == B_PRED {
-                for y in range(0us, 4) {
-                    for x in range(0us, 4) {
+                for y in (0us..4) {
+                    for x in (0us..4) {
                         let top   = self.top.as_mut_slice()[mbx].bpred[12 + x];
                         let left  = self.left.bpred[y];
                         let bmode = self.b.read_with_tree(&KEYFRAME_BPRED_MODE_TREE,
@@ -1154,7 +1154,7 @@ impl<R: Reader> VP8Decoder<R> {
                     }
                 }
             } else {
-                for i in range(0us, 4) {
+                for i in (0us..4) {
                     let mode = match mb.luma_mode {
                         DC_PRED => B_DC_PRED,
                         V_PRED  => B_VE_PRED,
@@ -1196,8 +1196,8 @@ impl<R: Reader> VP8Decoder<R> {
         }
 
         if mb.luma_mode != B_PRED {
-            for y in range(0us, 4) {
-                for x in range(0us, 4) {
+            for y in (0us..4) {
+                for x in (0us..4) {
                     let i  = x + y * 4;
                     let rb = resdata.slice(i * 16, i * 16 + 16);
                     let y0 = 1 + y * 4;
@@ -1210,7 +1210,7 @@ impl<R: Reader> VP8Decoder<R> {
 
         self.left_border.as_mut_slice()[0] = ws[16];
 
-        for i in range(0us, 16) {
+        for i in (0us..16) {
             self.top_border.as_mut_slice()[mbx * 16 + i] = ws[16 * stride + 1 + i];
             self.left_border.as_mut_slice()[i + 1] = ws[(i + 1) * stride + 16];
         }
@@ -1223,8 +1223,8 @@ impl<R: Reader> VP8Decoder<R> {
                       else if self.frame.width % 16 == 0 { 16us }
                       else { (16 - (self.frame.width as usize & 15)) % 16 };
 
-        for y in range(0us, ylength) {
-            for x in range(0us, xlength) {
+        for y in (0us..ylength) {
+            for x in (0us..xlength) {
                 self.frame.ybuf.as_mut_slice()[(mby * 16 + y) * w + mbx * 16 + x] =
                     ws[(1 + y) * stride + 1 + x];
             }
@@ -1247,7 +1247,7 @@ impl<R: Reader> VP8Decoder<R> {
         let mut has_coefficients = false;
         let mut skip = false;
 
-        for i in range(first, 16us) {
+        for i in (first..16us) {
             let table = probs[COEFF_BANDS[i] as usize][complexity].as_slice();
 
             let token = if !skip {
@@ -1322,16 +1322,16 @@ impl<R: Reader> VP8Decoder<R> {
 
             transform::iwht4x4(&mut block);
 
-            for k in range(0us, 16) {
+            for k in (0us..16) {
                 blocks[16 * k] = block[k];
             }
 
             plane = 0;
         }
 
-        for y in range(0us, 4) {
+        for y in (0us..4) {
             let mut left = self.left.complexity[y + 1];
-            for x in range(0us, 4) {
+            for x in (0us..4) {
                 let i = x + y * 4;
                 let block = blocks.slice_mut(i * 16, i * 16 + 16);
 
@@ -1355,10 +1355,10 @@ impl<R: Reader> VP8Decoder<R> {
         plane = 2;
 
         for &j in [5us, 7us].iter() {
-            for y in range(0us, 2) {
+            for y in (0us..2) {
                 let mut left = self.left.complexity[y + j];
 
-                for x in range(0us, 2) {
+                for x in (0us..2) {
                     let i = x + y * 2 + if j == 5 { 16 } else { 20 };
                     let block = blocks.slice_mut(i * 16, i * 16 + 16);
 
@@ -1386,11 +1386,11 @@ impl<R: Reader> VP8Decoder<R> {
     pub fn decode_frame(&mut self) -> IoResult<&Frame> {
         let _ = try!(self.read_frame_header());
 
-        for mby in range(0, self.mbheight as usize) {
+        for mby in (0..self.mbheight as usize) {
             let p = mby % self.num_partitions as usize;
             self.left = MacroBlock::new();
 
-            for mbx in range(0, self.mbwidth as usize) {
+            for mbx in (0..self.mbwidth as usize) {
                 let (skip, mb) = self.read_macroblock_header(mbx);
                 let mut blocks = [0i32; 384];
 
@@ -1402,7 +1402,7 @@ impl<R: Reader> VP8Decoder<R> {
                         self.top.as_mut_slice()[mbx].complexity[0] = 0;
                     }
 
-                    for i in range(1us, 9) {
+                    for i in (1us..9) {
                         self.left.complexity[i] = 0;
                         self.top.as_mut_slice()[mbx].complexity[i] = 0;
                     }
@@ -1439,27 +1439,27 @@ fn create_border(mbx: usize, mby: usize, mbw: usize, top: &[u8], left: &[u8]) ->
     {
         let above = ws.slice_mut(1, stride);
         if mby == 0 {
-            for i in range(0us, above.len()) {
+            for i in (0us..above.len()) {
                 above[i] = 127;
             }
         } else  {
-            for i in range(0us, 16) {
+            for i in (0us..16) {
                 above[i] = top[mbx * 16 + i];
             }
 
             if mbx == mbw - 1 {
-                for i in range(16us, above.len()) {
+                for i in (16us..above.len()) {
                     above[i] = top[mbx * 16 + 15];
                 }
             } else {
-                for i in range(16us, above.len()) {
+                for i in (16us..above.len()) {
                     above[i] = top[mbx * 16 + i];
                 }
             }
         }
     }
 
-    for i in range(17us, stride) {
+    for i in (17us..stride) {
         ws[4  * stride + i] = ws[i];
         ws[8  * stride + i] = ws[i];
         ws[12 * stride + i] = ws[i];
@@ -1467,11 +1467,11 @@ fn create_border(mbx: usize, mby: usize, mbw: usize, top: &[u8], left: &[u8]) ->
 
     // L
     if mbx == 0 {
-        for i in range(0us, 16) {
+        for i in (0us..16) {
             ws[(i + 1) * stride] = 129;
         }
     } else {
-        for i in range(0us, 16) {
+        for i in (0us..16) {
             ws[(i + 1) * stride] = left[i + 1];
         }
     }
@@ -1507,8 +1507,8 @@ fn clip<N: PartialOrd>(a: N, min: N, max: N) -> N {
 }
 
 fn add_residue(pblock: &mut [u8], rblock: &[i32], y0: usize, x0: usize, stride: usize) {
-    for y in range(0us, 4) {
-        for x in range(0us, 4) {
+    for y in (0us..4) {
+        for x in (0us..4) {
             let a = rblock[x + y * 4];
             let b = pblock[(y0 + y) * stride + x0 + x];
             let c = clip(a + b as i32, 0, 255) as u8;
@@ -1518,8 +1518,8 @@ fn add_residue(pblock: &mut [u8], rblock: &[i32], y0: usize, x0: usize, stride: 
 }
 
 fn predict_4x4(ws: &mut [u8], stride: usize, modes: &[i8], resdata: &[i32]) {
-    for sby in range(0us, 4) {
-        for sbx in range(0us, 4) {
+    for sby in (0us..4) {
+        for sbx in (0us..4) {
             let i  = sbx + sby * 4;
             let y0 = sby * 4 + 1;
             let x0 = sbx * 4 + 1;
@@ -1545,16 +1545,16 @@ fn predict_4x4(ws: &mut [u8], stride: usize, modes: &[i8], resdata: &[i32]) {
 }
 
 fn predict_vpred(a: &mut [u8], size: usize, x0: usize, y0: usize, stride: usize) {
-    for y in range(0us, size) {
-        for x in range(0us, size) {
+    for y in (0us..size) {
+        for x in (0us..size) {
             a[(x + x0) + stride * (y + y0)] = a[(x + x0) + stride * (y0 + y - 1)];
         }
     }
 }
 
 fn predict_hpred(a: &mut [u8], size: usize, x0: usize, y0: usize, stride: usize) {
-    for y in range(0us, size) {
-        for x in range(0us, size) {
+    for y in (0us..size) {
+        for x in (0us..size) {
             a[(x + x0) + stride * (y + y0)] = a[(x + x0 - 1) + stride * (y0 + y)];
         }
     }
@@ -1565,7 +1565,7 @@ fn predict_dcpred(a: &mut [u8], size: usize, stride: usize, above: bool, left: b
     let mut shf = if size == 8 {2} else {3};
 
     if left {
-        for y in range(0us, size) {
+        for y in (0us..size) {
             sum += a[(y + 1) * stride] as u32;
         }
 
@@ -1573,7 +1573,7 @@ fn predict_dcpred(a: &mut [u8], size: usize, stride: usize, above: bool, left: b
     }
 
     if above {
-        for x in range(0us, size) {
+        for x in (0us..size) {
             sum += a[x + 1] as u32;
         }
 
@@ -1586,16 +1586,16 @@ fn predict_dcpred(a: &mut [u8], size: usize, stride: usize, above: bool, left: b
         (sum + (1 << (shf - 1))) >> shf
     };
 
-    for y in range(0us, size) {
-        for x in range(0us, size) {
+    for y in (0us..size) {
+        for x in (0us..size) {
             a[(x + 1) + stride * (y + 1)] = dcval as u8;
         }
     }
 }
 
 fn predict_tmpred(a: &mut [u8], size: usize, x0: usize, y0: usize, stride: usize) {
-    for y in range(0us, size) {
-        for x in range(0us, size) {
+    for y in (0us..size) {
+        for x in (0us..size) {
             let pred = a[(y0 + y) * stride + x0 - 1] as i32 +
                        a[(y0 - 1) * stride + x0 + x] as i32 -
                        a[(y0 - 1) * stride + x0 - 1] as i32;
@@ -1607,14 +1607,14 @@ fn predict_tmpred(a: &mut [u8], size: usize, x0: usize, y0: usize, stride: usize
 
 fn predict_bdcpred(a: &mut [u8], x0: usize, y0: usize, stride: usize) {
     let mut v = 4;
-    for i in range(0us, 4) {
+    for i in (0us..4) {
             v += a[(y0 + i) * stride + x0 - 1] as u32 +
                  a[(y0 - 1) * stride + x0 + i] as u32;
     }
 
     v >>= 3;
-    for y in range(0us, 4) {
-        for x in range(0us, 4) {
+    for y in (0us..4) {
+        for x in (0us..4) {
             a[x + x0 + stride * (y + y0)] = v as u8;
         }
     }


### PR DESCRIPTION
Fixes warnings of the form:

    warning: use of unstable item: will be replaced by range notation, #[warn(unstable)] on by default

From rust 1.0.0-alpha update.