### PR TITLE
Slice notation

### DIFF
--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -29,7 +29,7 @@ fn main() {
 
         let mut i = 0;
 
-        for t in range(0, max_iterations) {
+        for t in (0..max_iterations) {
             if z.norm() > 2.0 {
                 break
             }

--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -9,7 +9,7 @@ use image::GenericImage;
 
 fn main() {
     let file = if os::args().len() == 2 {
-        os::args().as_slice()[1].clone()
+        os::args()[1].clone()
     } else {
         panic!("Please enter a file")
     };
@@ -24,7 +24,7 @@ fn main() {
     //The color method returns the image's ColorType
     println!("{:?}", im.color());
 
-    let fout = File::create(&Path::new(format!("{}.png", os::args().as_slice()[1]))).unwrap();
+    let fout = File::create(&Path::new(format!("{}.png", os::args()[1]))).unwrap();
 
     //Write the contents of this image to the Writer in PNG format.
     let _ = im.save(fout, image::PNG).unwrap();

--- a/src/color.rs
+++ b/src/color.rs
@@ -73,12 +73,12 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
     #[inline(always)]
     fn channels(&self) -> &[T] {
         let &$ident(ref this) = self;
-        this.as_slice()
+        &this[]
     }
     #[inline(always)]
     fn channels_mut(&mut self) -> &mut [T] {
         let &mut $ident(ref mut this) = self;
-        this.as_mut_slice()
+        &mut this[]
     }
 
     #[allow(unused_typecasts)]
@@ -107,7 +107,7 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
     }
 
     fn from_channels(a: T, b: T, c: T, d: T,) -> $ident<T> {
-        *Pixel::from_slice(None::<&$ident<T>>, [a, b, c, d].slice_to($channels))
+        *Pixel::from_slice(None::<&$ident<T>>, &[a, b, c, d][..$channels])
     }
 
     fn from_slice<'a>(_: Option<&'a $ident<T>>, slice: &'a [T]) -> &'a $ident<T> {
@@ -151,7 +151,7 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
 
     fn apply<F>(&mut self, f: F) where F: Fn(T) -> T {
         let &mut $ident(ref mut this) = self;
-        for v in this.as_mut_slice().iter_mut() {
+        for v in this[].iter_mut() {
             *v = f(*v)
         }
     }
@@ -165,11 +165,11 @@ impl<T: Primitive> Pixel<T> for $ident<T> {
     #[allow(unused_typecasts)]
     fn apply_with_alpha<F, G>(&mut self, f: F, g: G) where F: Fn(T) -> T, G: Fn(T) -> T {
         let &mut $ident(ref mut this) = self;
-        for v in this.as_mut_slice().slice_to_mut($channels as usize-$alphas as usize).iter_mut() {
+        for v in this[..$channels as usize-$alphas as usize].iter_mut() {
             *v = f(*v)
         }
         if $alphas as usize != 0 {
-            let ref mut v = this.as_mut_slice()[$channels as usize-$alphas as usize-1];
+            let ref mut v = this[$channels as usize-$alphas as usize-1];
             *v = g(*v)
         }
     }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -318,21 +318,21 @@ impl DynamicImage {
             image::ImageFormat::PNG  => {
                 let mut p = png::PNGEncoder::new(w);
 
-                try!(p.encode(bytes.as_slice(), width, height, color));
+                try!(p.encode(&bytes[], width, height, color));
                 Ok(())
             }
 
             image::ImageFormat::PPM  => {
                 let mut p = ppm::PPMEncoder::new(w);
 
-                try!(p.encode(bytes.as_slice(), width, height, color));
+                try!(p.encode(&bytes[], width, height, color));
                 Ok(())
             }
 
             image::ImageFormat::JPEG => {
                 let mut j = jpeg::JPEGEncoder::new(w);
 
-                try!(j.encode(bytes.as_slice(), width, height, color));
+                try!(j.encode(&bytes[], width, height, color));
                 Ok(())
             }
 
@@ -414,7 +414,7 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
             let scaling_factor = (255)/((1 << bit_depth as usize) - 1);
             let skip = (w % 8)/bit_depth as u32;
             let row_len = w + skip;
-            let p = buf.as_slice()
+            let p = buf[]
                        .iter()
                        .flat_map(|&v|
                            iter::range_step_inclusive(8i8-(bit_depth as i8), 0, -(bit_depth as i8))
@@ -473,7 +473,7 @@ pub fn open(path: &Path) -> ImageResult<DynamicImage> {
     let ext = path.extension_str()
                   .map_or("".to_string(), | s | s.to_string().into_ascii_lowercase());
 
-    let format = match ext.as_slice() {
+    let format = match &ext[] {
         "jpg" |
         "jpeg" => image::ImageFormat::JPEG,
         "png"  => image::ImageFormat::PNG,
@@ -503,7 +503,7 @@ pub fn save_buffer(path: &Path, buf: &[u8], width: u32, height: u32, color: colo
     let ext = path.extension_str()
                   .map_or("".to_string(), | s | s.to_string().into_ascii_lowercase());
 
-    match ext.as_slice() {
+    match &ext[] {
         "jpg" |
         "jpeg" => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
         "png"  => png::PNGEncoder::new(fout).encode(buf, width, height, color),
@@ -546,7 +546,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 7] = [
 /// TGA is not supported by this function.
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
     let max_len = MAGIC_BYTES.iter().map(|v| v.0.len()).max().unwrap_or(0);
-    let beginning = buffer.slice_to(max_len);
+    let beginning = &buffer[..max_len];
     for &(signature, format) in MAGIC_BYTES.iter() {
         if beginning.starts_with(signature) {
             return load_from_memory_with_format(buffer, format)

--- a/src/gif/bits.rs
+++ b/src/gif/bits.rs
@@ -135,7 +135,7 @@ mod test {
     fn reader_writer() {
         let data = [255, 20, 40, 120, 128];
         let mut expanded_data = Vec::new();
-        let mut reader = super::BitReader::new(data.as_slice());
+        let mut reader = super::BitReader::new(&data[]);
         while let Ok(b) = reader.read_bits(10) {
             expanded_data.push(b as u32)
         }
@@ -146,6 +146,6 @@ mod test {
                 let _  = writer.write_bits(datum, 10);
             }   
         }
-        assert_eq!(data.as_slice(), compressed_data.as_slice())
+        assert_eq!(&data[], &compressed_data[])
     }
 }

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -74,12 +74,12 @@ impl<R: Reader> GIFDecoder<R> {
         if self.state == State::Start {
             let mut signature = [0; 3];
             let mut version = [0; 3];
-            try!(self.r.read_at_least(3, signature.as_mut_slice()));
-            try!(self.r.read_at_least(3, version.as_mut_slice()));
+            try!(self.r.read_at_least(3, &mut signature[]));
+            try!(self.r.read_at_least(3, &mut version[]));
 
-            if signature.as_slice() != b"GIF" {
+            if &signature[] != b"GIF" {
                 Err(ImageError::FormatError("GIF signature not found.".to_string()))
-            } else if version.as_slice() != b"87a" && version.as_slice() != b"89a" {
+            } else if &version[] != b"87a" && &version[] != b"89a" {
                 Err(ImageError::UnsupportedError(
                     format!("GIF version {:?} is not supported.", version)
                 ))
@@ -116,7 +116,7 @@ impl<R: Reader> GIFDecoder<R> {
 
             let buf = try!(self.r.read_exact(3 * entries));
 
-            for rgb in buf.as_slice().chunks(3) {
+            for rgb in buf[].chunks(3) {
                 self.global_table.push((rgb[0], rgb[1], rgb[2]));
             }
             self.state = State::HaveLSD;
@@ -177,7 +177,7 @@ impl<R: Reader> GIFDecoder<R> {
         let mut size = try!(self.r.read_u8()) as usize;
         let mut data = Vec::with_capacity(size);
         while size != 0 {
-            data.push_all(try!(self.r.read_exact(size)).as_slice());
+            data.push_all(&try!(self.r.read_exact(size))[]);
             size = try!(self.r.read_u8()) as usize;
         }
         Ok(data)
@@ -207,7 +207,7 @@ impl<R: Reader> GIFDecoder<R> {
             let mut table = Vec::with_capacity(entries * 3);
             let buf = try!(self.r.read_exact(3 * entries));
 
-            for rgb in buf.as_slice().chunks(3) {
+            for rgb in buf[].chunks(3) {
                 table.push((rgb[0], rgb[1], rgb[2]));
             }
             Some(table)
@@ -229,9 +229,9 @@ impl<R: Reader> GIFDecoder<R> {
         ));
 
         let table = if let Some(ref table) = local_table {
-            table.as_slice()
+            &table[]
         } else {
-            self.global_table.as_slice()
+            &self.global_table[]
         };
 
         let image: Option<GreyImage> = ImageBuffer::from_vec(

--- a/src/gif/lzw.rs
+++ b/src/gif/lzw.rs
@@ -53,13 +53,13 @@ impl DecodingDict {
             self.buffer.push(cha);
         }
         self.buffer.reverse();
-        self.buffer.as_slice()
+        &self.buffer[]
     }
 
     /// Returns the buffer constructed by the last reconstruction
     #[inline(always)]
     fn buffer(&self) -> &[u8] {
-        self.buffer.as_slice()
+        &self.buffer[]
     }
 
     /// Number of entries in the dictionary

--- a/src/image.rs
+++ b/src/image.rs
@@ -141,7 +141,7 @@ pub trait ImageDecoder: Sized {
         let mut tmp = repeat(0u8).take(rowlen).collect::<Vec<u8>>();
 
         loop {
-            let row = try!(self.read_scanline(tmp.as_mut_slice()));
+            let row = try!(self.read_scanline(&mut tmp[]));
 
             if row - 1 == y {
                 break
@@ -150,16 +150,14 @@ pub trait ImageDecoder: Sized {
 
         for i in (0..length as usize) {
             {
-                let from = tmp.slice_from(x as usize * bpp)
-                              .slice_to(width as usize * bpp);
+                let from = &tmp[x as usize * bpp..width as usize * bpp];
 
-                let to   = buf.slice_from_mut(i * width as usize * bpp)
-                              .slice_to_mut(width as usize * bpp);
+                let to   = &mut buf[i * width as usize * bpp..width as usize * bpp];
 
                 slice::bytes::copy_memory(to, from);
             }
 
-            let _ = try!(self.read_scanline(tmp.as_mut_slice()));
+            let _ = try!(self.read_scanline(&mut tmp[]));
         }
 
         Ok(buf)

--- a/src/image.rs
+++ b/src/image.rs
@@ -148,7 +148,7 @@ pub trait ImageDecoder: Sized {
             }
         }
 
-        for i in range(0, length as usize) {
+        for i in (0..length as usize) {
             {
                 let from = tmp.slice_from(x as usize * bpp)
                               .slice_to(width as usize * bpp);
@@ -343,8 +343,8 @@ impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubI
     pub fn to_image(&self) -> ImageBuffer<Vec<T>, T, P> {
         let mut out = ImageBuffer::new(self.xstride, self.ystride);
 
-        for y in range(0, self.ystride) {
-            for x in range(0, self.xstride) {
+        for y in (0..self.ystride) {
+            for x in (0..self.xstride) {
                 let p = self.get_pixel(x, y);
                 out.put_pixel(x, y, p);
             }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -581,8 +581,8 @@ impl<R: Reader> ImageDecoder for JPEGDecoder<R> {
         }
 
         let len   = self.padded_width * self.num_components as usize;
-        let slice = self.mcu_row.slice(self.row_count as usize * len,
-        self.row_count as usize * len + buf.len());
+        let slice = &self.mcu_row[self.row_count as usize * len..
+        self.row_count as usize * len + buf.len()];
 
         slice::bytes::copy_memory(buf, slice);
 
@@ -619,7 +619,7 @@ fn upsample_mcu(out: &mut [u8], xoffset: usize, width: usize, bpp: usize, mcu: &
         let y_blocks = h * v;
 
         let y_blocks = &mcu[..y_blocks as usize * 64];
-        let cb = mcu.slice(y_blocks.len(), y_blocks.len() + 64);
+        let cb = &mcu[y_blocks.len()..y_blocks.len() + 64];
         let cr = &mcu[y_blocks.len() + cb.len()..];
 
         let mut k = 0;

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -120,13 +120,13 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
         j = 0;
 
         while j < bits[i] {
-            huffsize.as_mut_slice()[k] = i as u8 + 1;
+            huffsize[k] = i as u8 + 1;
             k += 1;
             j += 1;
         }
     }
 
-    huffsize.as_mut_slice()[k] = 0;
+    huffsize[k] = 0;
 
     // Annex C.2
     // Figure C.2
@@ -136,7 +136,7 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
     let mut size = huffsize[0];
 
     while huffsize[k] != 0 {
-        huffcode.as_mut_slice()[k] = code;
+        huffcode[k] = code;
         code += 1;
         k += 1;
 
@@ -158,7 +158,7 @@ pub fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
     let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 
     for (i, &v) in huffval.iter().enumerate() {
-        lut.as_mut_slice()[v as usize] = (huffsize[i], huffcode[i]);
+        lut[v as usize] = (huffsize[i], huffcode[i]);
     }
 
     lut
@@ -170,7 +170,7 @@ pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
     let mut valptr  = repeat(-1is).take(16).collect::<Vec<isize>>();
     let mut lut     = repeat((0u8, 17u8)).take(256).collect::<Vec<(u8, u8)>>();
 
-    let (huffsize, huffcode) = derive_codes_and_sizes(bits.as_slice());
+    let (huffsize, huffcode) = derive_codes_and_sizes(&bits[]);
 
     // Annex F.2.2.3
     // Figure F.15
@@ -178,10 +178,10 @@ pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
 
     for i in (0us..16) {
         if bits[i] != 0 {
-            valptr.as_mut_slice()[i] = j;
-            mincode.as_mut_slice()[i] = huffcode[j as usize] as isize;
+            valptr[i] = j;
+            mincode[i] = huffcode[j as usize] as isize;
             j += bits[i] as isize - 1;
-            maxcode.as_mut_slice()[i] = huffcode[j as usize] as isize;
+            maxcode[i] = huffcode[j as usize] as isize;
 
             j += 1;
         }
@@ -196,7 +196,7 @@ pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
 
         for j in (0us..1 << r) {
             let index = (huffcode[i] << r) + j as u16;
-            lut.as_mut_slice()[index as usize] = (*v, huffsize[i]);
+            lut[index as usize] = (*v, huffsize[i]);
         }
     }
 

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -281,7 +281,7 @@ impl<R: Reader> PNGDecoder<R> {
             return Err(ImageError::FormatError("Color palette malformed.".to_string()))
         }
 
-        let p: Vec<(u8, u8, u8)> = range(0, 256).map(|i| {
+        let p: Vec<(u8, u8, u8)> = (0..256).map(|i| {
             if i < len {
                 let r = buf[3 * i];
                 let g = buf[3 * i + 1];

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -469,7 +469,7 @@ impl<R: Reader> ImageDecoder for PNGDecoder<R> {
             }
             Ok(DecodingResult::U8(buf))
         } else {
-            for chunk in buf.as_mut_slice().chunks_mut(max_rowlen) {
+            for chunk in buf[].chunks_mut(max_rowlen) {
                 let _ = try!(self.read_scanline(chunk));
             }
             Ok(DecodingResult::U8(buf))

--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -183,7 +183,7 @@ impl<R: Reader> Inflater<R> {
     }
 
     fn create_fixed_tables(&mut self) {
-        let lengths: Vec<u8> = range(0, 288).map(|i|
+        let lengths: Vec<u8> = (0..288).map(|i|
             if i < 144 { 8u8 }
             else if i < 256 { 9u8 }
             else if i < 280 { 7u8 }

--- a/src/png/encoder.rs
+++ b/src/png/encoder.rs
@@ -47,10 +47,10 @@ impl<W: Writer> PNGEncoder<W> {
         let _ = try!(self.write_signature());
         let (bytes, bpp) = build_ihdr(width, height, c);
 
-        let _ = try!(self.write_chunk("IHDR", bytes.as_slice()));
+        let _ = try!(self.write_chunk("IHDR", &bytes[]));
         let compressed_bytes = build_idat(image, bpp, width, height);
 
-        for chunk in compressed_bytes.as_slice().chunks(1024 * 256) {
+        for chunk in compressed_bytes[].chunks(1024 * 256) {
             let _ = try!(self.write_chunk("IDAT", chunk));
         }
 
@@ -64,7 +64,7 @@ impl<W: Writer> PNGEncoder<W> {
     fn write_chunk(&mut self, name: &str, buf: &[u8]) -> IoResult<()> {
         self.crc.reset();
         self.crc.update(name);
-        self.crc.update(buf.as_slice());
+        self.crc.update(&buf[]);
 
         let crc = self.crc.checksum();
 
@@ -129,7 +129,7 @@ fn sum_abs_difference(buf: &[u8]) -> i32 {
 }
 
 fn select_filter(rowlength: usize, bpp: usize, previous: &[u8], current_s: &mut [u8]) -> u8 {
-    let mut sum    = sum_abs_difference(current_s.slice_to(rowlength));
+    let mut sum    = sum_abs_difference(&current_s[..rowlength]);
     let mut method = 0;
 
     for (i, current) in current_s.chunks_mut(rowlength).enumerate() {
@@ -155,24 +155,24 @@ fn build_idat(image: &[u8], bpp: usize, width: u32, height: u32) -> Vec<u8> {
     let mut c: Vec<u8> = repeat(0u8).take(4 * rowlen).collect();
     let mut b: Vec<u8> = repeat(0u8).take(height as usize + rowlen * height as usize).collect();
 
-    for (row, outrow) in image.as_slice().chunks(rowlen).zip(b.as_mut_slice().chunks_mut(1 + rowlen)) {
-        for s in c.as_mut_slice().chunks_mut(rowlen) {
+    for (row, outrow) in image[].chunks(rowlen).zip(b[].chunks_mut(1 + rowlen)) {
+        for s in c[].chunks_mut(rowlen) {
             slice::bytes::copy_memory(s, row);
         }
 
-        let filter = select_filter(rowlen, bpp, p.as_slice(), c.as_mut_slice());
+        let filter = select_filter(rowlen, bpp, &p[], &mut c[]);
 
         outrow[0]  = filter;
-        let out    = outrow.slice_from_mut(1);
+        let out    = &mut outrow[1..];
         let stride = (filter as usize - 1) * rowlen;
 
         match filter {
             0 => slice::bytes::copy_memory(out, row),
-            _ => slice::bytes::copy_memory(out, c.slice(stride, stride + rowlen)),
+            _ => slice::bytes::copy_memory(out, &c[stride..stride + rowlen]),
         }
 
-        slice::bytes::copy_memory(p.as_mut_slice(), row);
+        slice::bytes::copy_memory(&mut p[], row);
     }
 
-    deflate_bytes_zlib(b.as_slice()).unwrap().as_slice().to_vec()
+    deflate_bytes_zlib(&b[]).unwrap()[].to_vec()
 }

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -67,7 +67,7 @@ pub fn unfilter(filter: FilterType, bpp: usize, previous: &[u8], current: &mut [
 
 pub fn filter(method: FilterType, bpp: usize, previous: &[u8], current: &mut [u8]) {
     let len  = current.len();
-    let orig: Vec<u8> = range(0, len).map(| i | current[i]).collect();
+    let orig: Vec<u8> = (0..len).map(| i | current[i]).collect();
 
     match method {
         FilterType::NoFilter => (),

--- a/src/png/zlib.rs
+++ b/src/png/zlib.rs
@@ -73,7 +73,7 @@ impl<R: Reader> Reader for ZlibDecoder<R> {
             ZlibState::CompressedData => {
                 match self.inflate.read(buf) {
                     Ok(n) => {
-                        self.adler.update(buf.slice_to(n));
+                        self.adler.update(&buf[..n]);
 
                         if self.inflate.eof() {
                             let _ = try!(self.read_checksum());

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -43,7 +43,7 @@ impl<W: Writer> PPMEncoder<W> {
         let h = fmt::radix(height, 10);
         let m = max_pixel_value(pixel_type);
 
-        self.w.write_str(format!("{0} {1}\n{2}\n", w, h, m).as_slice())
+        self.w.write_str(&format!("{0} {1}\n{2}\n", w, h, m)[])
     }
 
     fn write_image(

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -149,7 +149,7 @@ impl ColorMap {
     /// Get one entry from the color map
     pub fn get(&self, index: usize) -> &[u8] {
         let entry = self.start_offset + self.entry_size * index;
-        self.bytes.as_slice().slice(entry, entry + self.entry_size)
+        &self.bytes[entry..entry + self.entry_size]
     }
 }
 
@@ -285,7 +285,7 @@ impl<R: Reader + Seek> TGADecoder<R> {
             None => unreachable!(),
         };
 
-        for chunk in pixel_data.as_slice().chunks(self.bytes_per_pixel) {
+        for chunk in pixel_data[].chunks(self.bytes_per_pixel) {
             let index = bytes_to_index(chunk);
             result.push_all(color_map.get(index));
         }
@@ -307,7 +307,7 @@ impl<R: Reader + Seek> TGADecoder<R> {
             pixel_data = self.expand_color_map(pixel_data)
         }
 
-        self.reverse_encoding(pixel_data.as_mut_slice());
+        self.reverse_encoding(&mut pixel_data[]);
         Ok(pixel_data)
     }
 
@@ -329,14 +329,14 @@ impl<R: Reader + Seek> TGADecoder<R> {
                 let repeat_count = ((run_packet & !0x80) + 1) as usize;
                 let data = try!(self.r.read_exact(self.bytes_per_pixel));
                 for _ in (0us..repeat_count) {
-                    pixel_data.push_all(data.as_slice());
+                    pixel_data.push_all(&data[]);
                 }
                 num_read += repeat_count;
             } else {
                 // not set, so `run_packet+1` is the number of non-encoded bytes
                 let num_raw_bytes = (run_packet + 1) as usize * self.bytes_per_pixel;
                 let data = try!(self.r.read_exact(num_raw_bytes));
-                pixel_data.push_all(data.as_slice());
+                pixel_data.push_all(&data[]);
                 num_read += run_packet as usize;
             }
         }
@@ -352,14 +352,14 @@ impl<R: Reader + Seek> TGADecoder<R> {
         // We only need to reverse the encoding of color images
         match self.color_type {
             ColorType::RGB(8) => {
-                for chunk in pixels.as_mut_slice().chunks_mut(self.bytes_per_pixel) {
+                for chunk in pixels[].chunks_mut(self.bytes_per_pixel) {
                     let r = chunk[0];
                     chunk[0] = chunk[2];
                     chunk[2] = r;
                 }
             }
             ColorType::RGBA(8) => {
-                for chunk in pixels.as_mut_slice().chunks_mut(self.bytes_per_pixel) {
+                for chunk in pixels[].chunks_mut(self.bytes_per_pixel) {
                     let r = chunk[0];
                     chunk[0] = chunk[2];
                     chunk[2] = r;

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -93,11 +93,11 @@ pub struct Entry {
 
 impl ::std::fmt::Show for Entry {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        fmt.write_str(format!("Entry {{ type: {:?}, count: {:?}, offset: {:?} }}",
+        fmt.write_str(&format!("Entry {{ type: {:?}, count: {:?}, offset: {:?} }}",
             self.type_,
             self.count,
-            self.offset.as_slice()
-        ).as_slice())
+            &self.offset[]
+        )[])
     }
 }
     
@@ -113,7 +113,7 @@ impl Entry {
     /// Returns a mem_reader for the offset/value field
     fn r(&self, byte_order: ByteOrder) -> SmartReader<io::MemReader> {
         SmartReader::wrap(
-            io::MemReader::new(self.offset.as_slice().to_vec()),
+            io::MemReader::new(self.offset[].to_vec()),
             byte_order
         )
     }

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -40,11 +40,11 @@ impl<R: Reader> WebpDecoder<R> {
         let size = try!(self.r.read_le_u32());
         let webp = try!(self.r.read_exact(4));
 
-        if riff.as_slice() != "RIFF".as_bytes() {
+        if &riff[] != "RIFF".as_bytes() {
             return Err(image::ImageError::FormatError("Invalid RIFF signature.".to_string()))
         }
 
-        if webp.as_slice() != "WEBP".as_bytes() {
+        if &webp[] != "WEBP".as_bytes() {
             return Err(image::ImageError::FormatError("Invalid WEBP signature.".to_string()))
         }
 
@@ -54,7 +54,7 @@ impl<R: Reader> WebpDecoder<R> {
     fn read_vp8_header(&mut self) -> ImageResult<()> {
         let vp8 = try!(self.r.read_exact(4));
 
-        if vp8.as_slice() != "VP8 ".as_bytes() {
+        if &vp8[] != "VP8 ".as_bytes() {
             return Err(image::ImageError::FormatError("Invalid VP8 signature.".to_string()))
         }
 
@@ -113,10 +113,10 @@ impl<R: Reader> ImageDecoder for WebpDecoder<R> {
         }
 
         let rlen  = buf.len();
-        let slice = self.frame.ybuf.slice(
-            self.decoded_rows as usize * rlen,
+        let slice = &self.frame.ybuf[
+            self.decoded_rows as usize * rlen..
             self.decoded_rows as usize * rlen + rlen
-        );
+        ];
 
         slice::bytes::copy_memory(buf, slice);
         self.decoded_rows += 1;

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -892,7 +892,7 @@ impl<R: Reader> VP8Decoder<R> {
         if n > 1 {
             let sizes = try!(self.r.read_exact(3 * n - 3));
 
-            for (i, s) in sizes.as_slice().chunks(3).enumerate() {
+            for (i, s) in sizes[].chunks(3).enumerate() {
                 let size = s[0] as u32 + ((s[1] as u32) << 8) + ((s[2] as u32) << 8);
                 let buf  = try!(self.r.read_exact(size as usize));
 
@@ -1039,7 +1039,7 @@ impl<R: Reader> VP8Decoder<R> {
             self.frame.height = h & 0x3FFF;
 
             self.top = init_top_macroblocks(self.frame.width as usize);
-            self.left = MacroBlock{..self.top.as_mut_slice()[0]};
+            self.left = MacroBlock{..self.top[0]};
 
             self.mbwidth  = (self.frame.width + 15) / 16;
             self.mbheight = (self.frame.height + 15) / 16;
@@ -1143,13 +1143,13 @@ impl<R: Reader> VP8Decoder<R> {
             if mb.luma_mode == B_PRED {
                 for y in (0us..4) {
                     for x in (0us..4) {
-                        let top   = self.top.as_mut_slice()[mbx].bpred[12 + x];
+                        let top   = self.top[mbx].bpred[12 + x];
                         let left  = self.left.bpred[y];
                         let bmode = self.b.read_with_tree(&KEYFRAME_BPRED_MODE_TREE,
                             &KEYFRAME_BPRED_MODE_PROBS[top as usize][left as usize], 0);
                         mb.bpred[x + y * 4] = bmode;
 
-                        self.top.as_mut_slice()[mbx].bpred[12 + x] = bmode;
+                        self.top[mbx].bpred[12 + x] = bmode;
                         self.left.bpred[y] = bmode;
                     }
                 }
@@ -1172,9 +1172,9 @@ impl<R: Reader> VP8Decoder<R> {
                                                    &KEYFRAME_UV_MODE_PROBS, 0);
         }
 
-        self.top.as_mut_slice()[mbx].chroma_mode = mb.chroma_mode;
-        self.top.as_mut_slice()[mbx].luma_mode = mb.luma_mode;
-        self.top.as_mut_slice()[mbx].bpred = mb.bpred;
+        self.top[mbx].chroma_mode = mb.chroma_mode;
+        self.top[mbx].luma_mode = mb.luma_mode;
+        self.top[mbx].bpred = mb.bpred;
 
         (skip_coeff, mb)
     }
@@ -1184,7 +1184,7 @@ impl<R: Reader> VP8Decoder<R> {
         let w  = self.frame.width as usize;
         let mw = self.mbwidth as usize;
         let mut ws = create_border(
-            mbx, mby, mw, self.top_border.as_slice(), self.left_border.as_slice());
+            mbx, mby, mw, &self.top_border[], &self.left_border[]);
 
         match mb.luma_mode {
             V_PRED  => predict_vpred(&mut ws, 16, 1, 1, stride),
@@ -1199,7 +1199,7 @@ impl<R: Reader> VP8Decoder<R> {
             for y in (0us..4) {
                 for x in (0us..4) {
                     let i  = x + y * 4;
-                    let rb = resdata.slice(i * 16, i * 16 + 16);
+                    let rb = &resdata[i * 16..i * 16 + 16];
                     let y0 = 1 + y * 4;
                     let x0 = 1 + x * 4;
 
@@ -1208,11 +1208,11 @@ impl<R: Reader> VP8Decoder<R> {
             }
         }
 
-        self.left_border.as_mut_slice()[0] = ws[16];
+        self.left_border[0] = ws[16];
 
         for i in (0us..16) {
-            self.top_border.as_mut_slice()[mbx * 16 + i] = ws[16 * stride + 1 + i];
-            self.left_border.as_mut_slice()[i + 1] = ws[(i + 1) * stride + 16];
+            self.top_border[mbx * 16 + i] = ws[16 * stride + 1 + i];
+            self.left_border[i + 1] = ws[(i + 1) * stride + 16];
         }
 
         let ylength = if mby < self.mbheight as usize - 1 { 16us }
@@ -1225,7 +1225,7 @@ impl<R: Reader> VP8Decoder<R> {
 
         for y in (0us..ylength) {
             for x in (0us..xlength) {
-                self.frame.ybuf.as_mut_slice()[(mby * 16 + y) * w + mbx * 16 + x] =
+                self.frame.ybuf[(mby * 16 + y) * w + mbx * 16 + x] =
                     ws[(1 + y) * stride + 1 + x];
             }
         }
@@ -1241,14 +1241,14 @@ impl<R: Reader> VP8Decoder<R> {
 
         let first = if plane == 0 { 1us } else { 0us };
         let probs = &self.token_probs[plane];
-        let tree  = DCT_TOKEN_TREE.as_slice();
+        let tree  = &DCT_TOKEN_TREE[];
 
         let mut complexity = complexity;
         let mut has_coefficients = false;
         let mut skip = false;
 
         for i in (first..16us) {
-            let table = probs[COEFF_BANDS[i] as usize][complexity].as_slice();
+            let table = &probs[COEFF_BANDS[i] as usize][complexity][];
 
             let token = if !skip {
                 self.partitions[p].read_with_tree(tree, table, 0)
@@ -1311,14 +1311,14 @@ impl<R: Reader> VP8Decoder<R> {
                          else { 1 };
 
         if plane == 1 {
-            let complexity = self.top.as_mut_slice()[mbx].complexity[0] + self.left.complexity[0];
+            let complexity = self.top[mbx].complexity[0] + self.left.complexity[0];
             let mut block = [0i32; 16];
             let dcq = self.segment[sindex].y2dc;
             let acq = self.segment[sindex].y2ac;
             let n   = self.read_coefficients(&mut block, p, plane, complexity as usize, dcq, acq);
 
             self.left.complexity[0] = if n { 1 } else { 0 };
-            self.top.as_mut_slice()[mbx].complexity[0] = if n { 1 } else { 0 };
+            self.top[mbx].complexity[0] = if n { 1 } else { 0 };
 
             transform::iwht4x4(&mut block);
 
@@ -1333,9 +1333,9 @@ impl<R: Reader> VP8Decoder<R> {
             let mut left = self.left.complexity[y + 1];
             for x in (0us..4) {
                 let i = x + y * 4;
-                let block = blocks.slice_mut(i * 16, i * 16 + 16);
+                let block = &mut blocks[i * 16..i * 16 + 16];
 
-                let complexity = self.top.as_mut_slice()[mbx].complexity[x + 1] + left;
+                let complexity = self.top[mbx].complexity[x + 1] + left;
                 let dcq = self.segment[sindex].ydc;
                 let acq = self.segment[sindex].yac;
 
@@ -1346,7 +1346,7 @@ impl<R: Reader> VP8Decoder<R> {
                 }
 
                 left = if n { 1 } else { 0 };
-                self.top.as_mut_slice()[mbx].complexity[x + 1] = if n { 1 } else { 0 };
+                self.top[mbx].complexity[x + 1] = if n { 1 } else { 0 };
             }
 
             self.left.complexity[y + 1] = left;
@@ -1360,9 +1360,9 @@ impl<R: Reader> VP8Decoder<R> {
 
                 for x in (0us..2) {
                     let i = x + y * 2 + if j == 5 { 16 } else { 20 };
-                    let block = blocks.slice_mut(i * 16, i * 16 + 16);
+                    let block = &mut blocks[i * 16..i * 16 + 16];
 
-                    let complexity = self.top.as_mut_slice()[mbx].complexity[x + j] + left;
+                    let complexity = self.top[mbx].complexity[x + j] + left;
                     let dcq   = self.segment[sindex].uvdc;
                     let acq   = self.segment[sindex].uvac;
 
@@ -1372,7 +1372,7 @@ impl<R: Reader> VP8Decoder<R> {
                     }
 
                     left = if n { 1 } else { 0 };
-                    self.top.as_mut_slice()[mbx].complexity[x + j] = if n { 1 } else { 0 };
+                    self.top[mbx].complexity[x + j] = if n { 1 } else { 0 };
                 }
 
                 self.left.complexity[y + j] = left;
@@ -1399,12 +1399,12 @@ impl<R: Reader> VP8Decoder<R> {
                 } else {
                     if mb.luma_mode != B_PRED {
                         self.left.complexity[0] = 0;
-                        self.top.as_mut_slice()[mbx].complexity[0] = 0;
+                        self.top[mbx].complexity[0] = 0;
                     }
 
                     for i in (1us..9) {
                         self.left.complexity[i] = 0;
-                        self.top.as_mut_slice()[mbx].complexity[i] = 0;
+                        self.top[mbx].complexity[i] = 0;
                     }
                 }
 
@@ -1437,7 +1437,7 @@ fn create_border(mbx: usize, mby: usize, mbw: usize, top: &[u8], left: &[u8]) ->
 
     // A
     {
-        let above = ws.slice_mut(1, stride);
+        let above = &mut ws[1..stride];
         if mby == 0 {
             for i in (0us..above.len()) {
                 above[i] = 127;
@@ -1523,7 +1523,7 @@ fn predict_4x4(ws: &mut [u8], stride: usize, modes: &[i8], resdata: &[i32]) {
             let i  = sbx + sby * 4;
             let y0 = sby * 4 + 1;
             let x0 = sbx * 4 + 1;
-            let rb = resdata.slice(i * 16, i * 16 + 16);
+            let rb = &resdata[i * 16..i * 16 + 16];
 
             match modes[i] {
                 B_TM_PRED => predict_tmpred(ws, 4, x0, y0, stride),

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -1428,7 +1428,7 @@ fn init_top_macroblocks(width: usize) -> Vec<MacroBlock> {
         ..MacroBlock::new()
     };
 
-    range(0, mb_width).map(|_| mb).collect()
+    (0..mb_width).map(|_| mb).collect()
 }
 
 fn create_border(mbx: usize, mby: usize, mbw: usize, top: &[u8], left: &[u8]) -> [u8; 357] {


### PR DESCRIPTION
A work in progress at the moment, but this fixes some of the `use of unstable item: will be replaced by slice syntax` warnings.

Some of the slicing in `src/jpeg/encoder.rs` looks odd. They can probably be exact indexes into the quantisation tables, but I don't want to muck them up (if I haven't already).

Also in `src/buffer.rs` I'm not sure what the `Container` trait implies, so that is not touched yet.