### PR TITLE
Use associated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,25 @@ All pixels are parameterised by their component type.
 A trait that provides functions for manipulating images, parameterised over the image's pixel type.
 
 ```rust
-pub trait GenericImage<P> {
-    ///The width and height of this image.
+pub trait GenericImage {
+    /// The pixel type.
+    type Pixel: Pixel;
+
+    /// The width and height of this image.
     fn dimensions(&self) -> (u32, u32);
 
-    ///The bounding rectangle of this image.
+    /// The bounding rectangle of this image.
     fn bounds(&self) -> (u32, u32, u32, u32);
 
-    ///Return the pixel located at (x, y)
+    /// Return the pixel located at (x, y)
     fn get_pixel(&self, x: u32, y: u32) -> P;
 
-    ///Put a pixel at location (x, y)
+    /// Put a pixel at location (x, y)
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P);
 
-    ///Return an Iterator over the pixels of this image.
-    ///The iterator yields the coordinates of each pixel
-    ///along with their value
+    /// Return an Iterator over the pixels of this image.
+    /// The iterator yields the coordinates of each pixel
+    /// along with their value
     fn pixels(&self) -> Pixels<Self>;
 }
 ```

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -484,7 +484,7 @@ impl<P: Pixel + 'static> ImageBuffer<P, Vec<P::Subpixel>>
 }
 
 /// Provides color conversions for whole image buffers.
-pub trait ConvertBuffer<T: ?Sized> {
+pub trait ConvertBuffer<T> {
     /// Converts `self` to a buffer of type T
     ///
     /// A generic impementation is provided to convert any image buffer to a image buffer

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -34,15 +34,18 @@ impl<A: Index<usize, Output=T> + IndexMut<usize, Output=T> + AsSlice<T> + AsMutS
 /// A generalized pixel.
 ///
 /// A pixel object is usually not used standalone but as a view into an image buffer.   
-pub trait Pixel<T: Primitive>: Copy + Clone {
+pub trait Pixel: Copy + Clone {
+    /// The underlying subpixel type.
+    type Subpixel: Primitive;
+
     /// Returns the number of channels of this pixel type.
     fn channel_count<'a>(_: Option<&'a Self>) -> u8;
 
     /// Returns the components as a slice.
-    fn channels(&self) -> &[T];
+    fn channels(&self) -> &[Self::Subpixel];
 
     /// Returns the components as a mutable slice
-    fn channels_mut(&mut self) -> &mut [T];
+    fn channels_mut(&mut self) -> &mut [Self::Subpixel];
 
     /// Returns a string that can help to interprete the meaning each channel
     /// See [gimp babl](http://gegl.org/babl/).
@@ -51,65 +54,68 @@ pub trait Pixel<T: Primitive>: Copy + Clone {
     /// Returns the channels of this pixel as a 4 tuple. If the pixel
     /// has less than 4 channels the remainder is filled with the maximum value
     /// TODO deprecate
-    fn channels4(&self) -> (T, T, T, T);
+    fn channels4(&self) -> (Self::Subpixel, Self::Subpixel, Self::Subpixel, Self::Subpixel);
 
     /// Construct a pixel from the 4 channels a, b, c and d.
     /// If the pixel does not contain 4 channels the extra are ignored.
     /// TODO deprecate
-    fn from_channels(a: T, b: T, c: T, d: T) -> Self;
+    fn from_channels(a: Self::Subpixel, b: Self::Subpixel, c: Self::Subpixel, d: Self::Subpixel) -> Self;
 
     /// Returns a view into a slice.
     ///
     /// Note: The slice length is not checked on creation. Thus the caller has to ensure
     /// that the slice is long enough to precent panics if the pixel is used later on.
-    fn from_slice<'a>(_: Option<&'a Self>, slice: &'a [T]) -> &'a Self;
+    fn from_slice<'a>(_: Option<&'a Self>, slice: &'a [Self::Subpixel]) -> &'a Self;
     
     /// Returns mutable view into a mutable slice.
     ///
     /// Note: The slice length is not checked on creation. Thus the caller has to ensure
     /// that the slice is long enough to precent panics if the pixel is used later on.
-    fn from_slice_mut<'a>(_: Option<&'a Self>, slice: &'a mut [T]) -> &'a mut Self;
+    fn from_slice_mut<'a>(_: Option<&'a Self>, slice: &'a mut [Self::Subpixel]) -> &'a mut Self;
     
     /// Convert this pixel to RGB
-    fn to_rgb(&self) -> Rgb<T>;
+    fn to_rgb(&self) -> Rgb<Self::Subpixel>;
 
     /// Convert this pixel to RGB with an alpha channel
-    fn to_rgba(&self) -> Rgba<T>;
+    fn to_rgba(&self) -> Rgba<Self::Subpixel>;
 
     /// Convert this pixel to luma
-    fn to_luma(&self) -> Luma<T>;
+    fn to_luma(&self) -> Luma<Self::Subpixel>;
 
     /// Convert this pixel to luma with an alpha channel
-    fn to_luma_alpha(&self) -> LumaA<T>;
+    fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn map<F>(&self, f: F) -> Self where F: Fn(T) -> T;
+    fn map<F>(&self, f: F) -> Self where F: Fn(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn apply<F>(&mut self, f: F) where F: Fn(T) -> T;
+    fn apply<F>(&mut self, f: F) where F: Fn(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function f to each channel except the alpha channel.
     /// Apply the function g to the alpha channel.
-    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self where F: Fn(T) -> T, G: Fn(T) -> T;
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
+        where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function f to each channel except the alpha channel.
     /// Apply the function g to the alpha channel. Works in-place.
-    fn apply_with_alpha<F, G>(&mut self, f: F, g: G) where F: Fn(T) -> T, G: Fn(T) -> T;
+    fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
+        where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise.
-    fn map2<F>(&self, other: &Self, f: F) -> Self where F: Fn(T, T) -> T;
+    fn map2<F>(&self, other: &Self, f: F) -> Self
+        where F: Fn(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise. Works in-place.
-    fn apply2<F>(&mut self, other: &Self, f: F) where F: Fn(T, T) -> T;
+    fn apply2<F>(&mut self, other: &Self, f: F)
+        where F: Fn(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
 
     /// Invert this pixel
     fn invert(&mut self);
 
     /// Blend the color of a given pixel into ourself, taking into account alpha channels
     fn blend(&mut self, other: &Self);
-    
 }
 
 /// Iterate over pixel refs. 
@@ -117,23 +123,25 @@ pub struct Pixels<'a, T: 'static, PixelType: ?Sized> {
     chunks: Chunks<'a, T>
 }
 
-impl<'a, T, PixelType> Iterator for Pixels<'a, T, PixelType> 
-where T: Primitive, PixelType: Pixel<T> {
-    type Item = &'a PixelType;
+impl<'a, P: Pixel> Iterator for Pixels<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
+    type Item = &'a P;
     #[inline(always)]
-    fn next(&mut self) -> Option<&'a PixelType> {
+    fn next(&mut self) -> Option<&'a P> {
         self.chunks.next().map(|v| 
-            Pixel::from_slice(None::<&'a PixelType>, v)
+            Pixel::from_slice(None::<&'a P>, v)
         )
     }
 }
 
-impl<'a, T, PixelType> DoubleEndedIterator for Pixels<'a, T, PixelType> 
-where T: Primitive, PixelType: Pixel<T> {
+impl<'a, P: Pixel> DoubleEndedIterator for Pixels<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
     #[inline(always)]
-    fn next_back(&mut self) -> Option<&'a PixelType> {
+    fn next_back(&mut self) -> Option<&'a P> {
         self.chunks.next_back().map(|v| 
-            Pixel::from_slice(None::<&'a PixelType>, v)
+            Pixel::from_slice(None::<&'a P>, v)
         )
     }
 }
@@ -143,23 +151,25 @@ pub struct PixelsMut<'a, T: 'static, PixelType: ?Sized> {
     chunks: ChunksMut<'a, T>
 }
 
-impl<'a, T, PixelType> Iterator for PixelsMut<'a, T, PixelType>
-where T: Primitive, PixelType: Pixel<T> {
-    type Item = &'a mut PixelType;
+impl<'a, P: Pixel> Iterator for PixelsMut<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
+    type Item = &'a mut P;
     #[inline(always)]
-    fn next(&mut self) -> Option<&'a mut PixelType> {
+    fn next(&mut self) -> Option<&'a mut P> {
         self.chunks.next().map(|v| 
-            Pixel::from_slice_mut(None::<&'a PixelType>, v)
+            Pixel::from_slice_mut(None::<&'a P>, v)
         )
     }
 }
 
-impl<'a, T, PixelType> DoubleEndedIterator for PixelsMut<'a, T, PixelType>
-where T: Primitive, PixelType: Pixel<T> {
+impl<'a, P: Pixel> DoubleEndedIterator for PixelsMut<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
     #[inline(always)]
-    fn next_back(&mut self) -> Option<&'a mut PixelType> {
+    fn next_back(&mut self) -> Option<&'a mut P> {
         self.chunks.next_back().map(|v| 
-            Pixel::from_slice_mut(None::<&'a PixelType>, v)
+            Pixel::from_slice_mut(None::<&'a P>, v)
         )
     }
 }
@@ -172,12 +182,12 @@ pub struct EnumeratePixels<'a, T: 'static, PixelType: ?Sized> {
     width:  u32
 }
 
-impl<'a, T, PixelType> Iterator
-for EnumeratePixels<'a, T, PixelType>
-where T: Primitive, PixelType: Pixel<T> {
-    type Item = (u32, u32, &'a PixelType);
+impl<'a, P: Pixel> Iterator for EnumeratePixels<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
+    type Item = (u32, u32, &'a P);
     #[inline(always)]
-    fn next(&mut self) -> Option<(u32, u32, &'a PixelType)> {
+    fn next(&mut self) -> Option<(u32, u32, &'a P)> {
         if self.x >= self.width {
             self.x =  0;
             self.y += 1;
@@ -199,12 +209,12 @@ pub struct EnumeratePixelsMut<'a, T: 'static, PixelType: ?Sized> {
     width:  u32
 }
 
-impl<'a, T, PixelType> Iterator
-for EnumeratePixelsMut<'a, T, PixelType>
-where T: Primitive, PixelType: Pixel<T> {
-    type Item = (u32, u32, &'a mut PixelType);
+impl<'a, P: Pixel> Iterator for EnumeratePixelsMut<'a, P::Subpixel, P>
+    where P::Subpixel: Primitive {
+
+    type Item = (u32, u32, &'a mut P);
     #[inline(always)]
-    fn next(&mut self) -> Option<(u32, u32, &'a mut PixelType)> {
+    fn next(&mut self) -> Option<(u32, u32, &'a mut P)> {
         if self.x >= self.width {
             self.x =  0;
             self.y += 1;
@@ -230,22 +240,24 @@ where T: Primitive, Container: ArrayLike<T>, PixelType: 'static {
 } 
 
 // generic implementation, shared along all image buffers 
-impl<Container, T, PixelType> ImageBuffer<Container, T, PixelType> 
-where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'static {
+impl<Container, P: Pixel + 'static> ImageBuffer<Container, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static,
+          Container: ArrayLike<P::Subpixel> {
 
     /// Contructs a buffer from a generic container 
     /// (for example a `Vec` or a slice)
     /// Returns None if the container is not big enough
-    pub fn from_raw(width: u32, height: u32, buf: Container) -> Option<ImageBuffer<Container, T, PixelType>> {
-        if width as usize 
+    pub fn from_raw(width: u32, height: u32, buf: Container)
+                    -> Option<ImageBuffer<Container, P::Subpixel, P>> {
+        if width as usize
            * height as usize
-           * Pixel::channel_count(None::<&PixelType>) as usize 
+           * Pixel::channel_count(None::<&P>) as usize 
            <= buf.as_slice().len() {
             Some(ImageBuffer {
                 data: buf,
                 width: width,
                 height: height,
-                type_marker: TypeId::of::<PixelType>()
+                type_marker: TypeId::of::<P>()
             })
         } else {
             None
@@ -273,20 +285,20 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     }
 
     /// The raw image data as a slice.
-    pub fn as_slice(& self) -> &[T] {
+    pub fn as_slice(& self) -> &[P::Subpixel] {
         self.data.as_slice()
     }
 
     /// The raw image data as a slice.
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
+    pub fn as_mut_slice(&mut self) -> &mut [P::Subpixel] {
         self.data.as_mut_slice()
     }
 
     /// Returns an iterator over the pixels of this image.
-    pub fn pixels<'a>(&'a self) -> Pixels<'a, T, PixelType> {
+    pub fn pixels<'a>(&'a self) -> Pixels<'a, P::Subpixel, P> {
         Pixels {
             chunks: self.data.as_slice().chunks(
-                Pixel::channel_count(None::<&PixelType>) as usize
+                Pixel::channel_count(None::<&P>) as usize
             )
         }
     }
@@ -294,10 +306,10 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// Returns an iterator over the mutable pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with a mutable reference to them.
-    pub fn pixels_mut(&mut self) -> PixelsMut<T, PixelType> {
+    pub fn pixels_mut(&mut self) -> PixelsMut<P::Subpixel, P> {
         PixelsMut {
             chunks: self.data.as_mut_slice().chunks_mut(
-                Pixel::channel_count(None::<&PixelType>) as usize
+                Pixel::channel_count(None::<&P>) as usize
             )
         }
     }
@@ -305,7 +317,7 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// Enumerates over the pixels of the image.
     /// The iterator yields the coordinates of each pixel
     /// along with a reference to them.
-    pub fn enumerate_pixels<'a>(&'a self) -> EnumeratePixels<'a, T, PixelType> {
+    pub fn enumerate_pixels<'a>(&'a self) -> EnumeratePixels<'a, P::Subpixel, P> {
         EnumeratePixels {
             pixels: self.pixels(),
             x: 0,
@@ -315,7 +327,7 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     }
 
     /// Enumerates over the pixels of the image.
-    pub fn enumerate_pixels_mut<'a>(&'a mut self) -> EnumeratePixelsMut<'a, T, PixelType> {
+    pub fn enumerate_pixels_mut<'a>(&'a mut self) -> EnumeratePixelsMut<'a, P::Subpixel, P> {
         let width = self.width;
         EnumeratePixelsMut {
             pixels: self.pixels_mut(),
@@ -330,11 +342,11 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
-    pub fn get_pixel(&self, x: u32, y: u32) -> &PixelType {
-        let no_channels = Pixel::channel_count(None::<&PixelType>) as usize;
+    pub fn get_pixel(&self, x: u32, y: u32) -> &P {
+        let no_channels = Pixel::channel_count(None::<&P>) as usize;
         let index  = no_channels * (y * self.width + x) as usize;
         Pixel::from_slice(
-            None::<&PixelType>,
+            None::<&P>,
             self.data.as_slice().slice(
                 index, index + no_channels
             )
@@ -346,11 +358,11 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
-    pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut PixelType {
-        let no_channels = Pixel::channel_count(None::<&PixelType>) as usize;
+    pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
+        let no_channels = Pixel::channel_count(None::<&P>) as usize;
         let index  = no_channels * (y * self.width + x) as usize;
         Pixel::from_slice_mut(
-            None::<&PixelType>,
+            None::<&P>,
             self.data.as_mut_slice().slice_mut(
                 index, index + no_channels
             )
@@ -362,13 +374,13 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of the bounds (width, height)`.
-    pub fn put_pixel(&mut self, x: u32, y: u32, pixel: PixelType) {
+    pub fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
     }
 
     /// Casts the buffer into a dynamically typed image buffer
     #[experimental]
-    pub fn into_dynamic(self) -> ImageBuffer<Container, T, &'static Any> {
+    pub fn into_dynamic(self) -> ImageBuffer<Container, P::Subpixel, &'static Any> {
         ImageBuffer {
             data: self.data,
             width: self.width,
@@ -380,11 +392,11 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
 }
 
 
-impl<Container, T, PixelType> Clone for ImageBuffer<Container, T, PixelType>
-where Container: ArrayLike<T> + Clone, 
-      T: Primitive + 'static, 
-      PixelType: Pixel<T> + 'static {
-    fn clone(&self) -> ImageBuffer<Container, T, PixelType> {
+impl<Container, P: Pixel + 'static> Clone for ImageBuffer<Container, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static,
+          Container: ArrayLike<P::Subpixel> + Clone {
+
+    fn clone(&self) -> ImageBuffer<Container, P::Subpixel, P> {
         ImageBuffer {
             data: self.data.clone(),
             width: self.width,
@@ -394,9 +406,10 @@ where Container: ArrayLike<T> + Clone,
     }
 }
 
-impl<Container, T, PixelType> GenericImage<PixelType> 
-for ImageBuffer<Container, T, PixelType>
-where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'static {
+impl<Container, P: Pixel + 'static> GenericImage<P>
+    for ImageBuffer<Container, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static,
+          Container: ArrayLike<P::Subpixel> {
 
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions()
@@ -406,54 +419,58 @@ where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'st
         (0, 0, self.width, self.height)
     }
 
-    fn get_pixel(&self, x: u32, y: u32) -> PixelType {
+    fn get_pixel(&self, x: u32, y: u32) -> P {
         *self.get_pixel(x, y)
     }
 
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut PixelType {
+    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
         self.get_pixel_mut(x, y)
     }
 
-    fn put_pixel(&mut self, x: u32, y: u32, pixel: PixelType) {
+    fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
     #[deprecated = "This method will be removed. Blend the pixel directly instead."]
-    fn blend_pixel(&mut self, x: u32, y: u32, p: PixelType) {
+    fn blend_pixel(&mut self, x: u32, y: u32, p: P) {
         self.get_pixel_mut(x, y).blend(&p)
     }
 }
 
-impl<Container, T, PixelType> Index<(u32, u32)>
-for ImageBuffer<Container, T, PixelType>
-where Container: ArrayLike<T>, T: Primitive + 'static, PixelType: Pixel<T> + 'static {
-    type Output = PixelType;
-    fn index(&self, &(x, y): &(u32, u32)) -> &PixelType {
+impl<Container, P: Pixel + 'static> Index<(u32, u32)>
+    for ImageBuffer<Container, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static,
+          Container: ArrayLike<P::Subpixel> {
+
+    type Output = P;
+    fn index(&self, &(x, y): &(u32, u32)) -> &P {
         self.get_pixel(x, y)
     }
 }
  
 // concrete implementation for `Vec`-baked buffers
-impl<T, PixelType> ImageBuffer<Vec<T>, T, PixelType>
-where T: Primitive + 'static, PixelType: Pixel<T> + 'static {
-    /// Creates a new image buffer based on a `Vec<T>`.
-    pub fn new(width: u32, height: u32) -> ImageBuffer<Vec<T>, T, PixelType> {
+impl<P: Pixel + 'static> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
+
+    /// Creates a new image buffer based on a `Vec<P::Subpixel>`.
+    pub fn new(width: u32, height: u32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> {
         ImageBuffer {
             data: repeat(Zero::zero()).take(
                     (width as u64
                      * height as u64 
-                     * (Pixel::channel_count(None::<&PixelType>) as u64)
+                     * (Pixel::channel_count(None::<&P>) as u64)
                     ) as usize
                 ).collect(),
             width: width,
             height: height,
-            type_marker: TypeId::of::<PixelType>()
+            type_marker: TypeId::of::<P>()
         }
     }
 
     /// Constructs a new ImageBuffer by copying a pixel
-    pub fn from_pixel(width: u32, height: u32, pixel: PixelType) -> ImageBuffer<Vec<T>, T, PixelType> {
+    pub fn from_pixel(width: u32, height: u32, pixel: P)
+                      -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> {
         let mut buf = ImageBuffer::new(width, height);
         for p in buf.pixels_mut() {
             *p = pixel
@@ -463,7 +480,8 @@ where T: Primitive + 'static, PixelType: Pixel<T> + 'static {
 
     /// Constructs a new ImageBuffer by repeated application of the supplied function.
     /// The arguments to the function are the pixel's x and y coordinates.
-    pub fn from_fn(width: u32, height: u32, f: Box<Fn(u32, u32) -> PixelType>) -> ImageBuffer<Vec<T>, T, PixelType> {
+    pub fn from_fn(width: u32, height: u32, f: Box<Fn(u32, u32) -> P>)
+                   -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> {
         let mut buf = ImageBuffer::new(width, height);
         for (x, y,  p) in buf.enumerate_pixels_mut() {
             *p = f(x, y)
@@ -473,13 +491,14 @@ where T: Primitive + 'static, PixelType: Pixel<T> + 'static {
 
     /// Creates an image buffer out of an existing buffer. 
     /// Returns None if the buffer is not big enough.
-    pub fn from_vec(width: u32, height: u32, buf: Vec<T>) -> Option<ImageBuffer<Vec<T>, T, PixelType>> {
+    pub fn from_vec(width: u32, height: u32, buf: Vec<P::Subpixel>)
+                    -> Option<ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>> {
         ImageBuffer::from_raw(width, height, buf)
     }
 
     /// Consumes the image buffer and returns the underlying data
     /// as an owned buffer
-    pub fn into_vec(self) -> Vec<T> {
+    pub fn into_vec(self) -> Vec<P::Subpixel> {
         self.into_raw()
     }
 }
@@ -532,13 +551,18 @@ impl GreyImage {
     }
 }
 
-impl<'a, 'b, Container, T, FromType, ToType> 
-    ConvertBuffer<ImageBuffer<Vec<T>,T, ToType>> 
-    for ImageBuffer<Container, T, FromType> 
-    where T: Primitive + 'static, 
-          Container: ArrayLike<T>, 
-          FromType: Pixel<T> + 'static, 
-          ToType: Pixel<T> + 'static + FromColor<FromType> {
+// TODO: Equality constraints are not yet supported in where clauses, when they
+// are, the T parameter should be removed in favor of ToType::Subpixel, which
+// will then be FromType::Subpixel.
+impl<'a, 'b, Container, T, FromType: Pixel, ToType: Pixel>
+    ConvertBuffer<ImageBuffer<Vec<T>,T, ToType>>
+    for ImageBuffer<Container, T, FromType>
+    where T: Primitive + 'static,
+          Container: ArrayLike<T>,
+          FromType: Pixel + 'static,
+          ToType: Pixel + 'static + FromColor<FromType>,
+          FromType::Subpixel: Primitive + 'static,
+          ToType::Subpixel: Primitive + 'static {
     fn convert(&self) -> ImageBuffer<Vec<T>, T, ToType> {
         let mut buffer = ImageBuffer::<T, ToType>::new(self.width, self.height);
         for (mut to, from) in buffer.pixels_mut().zip(self.pixels()) {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -497,7 +497,7 @@ pub trait ConvertBuffer<T: ?Sized> {
 }
 
 // concrete implementation Luma -> Rgba
-impl ImageBuffer<Luma<u8>, Vec<u8>> {
+impl GreyImage {
     /// Expands a color palette by re-using the existing buffer.
     /// Assumes 8 bit per pixel. Uses an optionally transparent index to 
     /// adjust it's alpha value accordingly.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -388,8 +388,10 @@ impl<P: Pixel, Container: ArrayLike<P::Subpixel> + Clone> Clone for ImageBuffer<
     }
 }
 
-impl<P: Pixel + 'static, Container: ArrayLike<P::Subpixel>> GenericImage<P>
+impl<P: Pixel + 'static, Container: ArrayLike<P::Subpixel>> GenericImage
     for ImageBuffer<P, Container> where P::Subpixel: 'static {
+
+    type Pixel = P;
 
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions()

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -231,7 +231,7 @@ impl<'a, P: Pixel> Iterator for EnumeratePixelsMut<'a, P::Subpixel, P>
 
 
 /// Generic image buffer
-pub struct ImageBuffer<P: Pixel, Container: ArrayLike<P::Subpixel>> {
+pub struct ImageBuffer<P: Pixel, Container> {
     width: u32,
     height: u32,
     type_marker: TypeId,

--- a/src/color.rs
+++ b/src/color.rs
@@ -232,7 +232,7 @@ define_colors! {
 
 
 /// Provides color conversions for the different pixel types.
-pub trait FromColor<Other: ?Sized> {
+pub trait FromColor<Other> {
     /// Changes `self` to represent `Other` in the color space of `Self`
     fn from_color(&mut self, &Other);
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -62,7 +62,9 @@ $( // START Structure definitions
 #[derive(PartialEq, Eq, Clone, Show, Copy)]
 pub struct $ident<T: Primitive>(pub [T; $channels]);
 
-impl<T: Primitive> Pixel<T> for $ident<T> {
+impl<T: Primitive> Pixel for $ident<T> {
+
+    type Subpixel = T;
 
     fn channel_count<'a>(_: Option<&'a $ident<T>>) -> u8 {
         $channels

--- a/src/color.rs
+++ b/src/color.rs
@@ -62,7 +62,7 @@ $( // START Structure definitions
 #[derive(PartialEq, Eq, Clone, Show, Copy)]
 pub struct $ident<T: Primitive>(pub [T; $channels]);
 
-impl<T: Primitive> Pixel for $ident<T> {
+impl<T: Primitive + 'static> Pixel for $ident<T> {
 
     type Subpixel = T;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -246,7 +246,7 @@ impl<A: Copy> FromColor<A> for A {
 
 /// FromColor for Luma
 
-impl<T: Primitive> FromColor<Rgba<T>> for Luma<T> {
+impl<T: Primitive + 'static> FromColor<Rgba<T>> for Luma<T> {
     fn from_color(&mut self, other: &Rgba<T>) {
             let gray = self.channels_mut();
             let rgb = other.channels();
@@ -257,7 +257,7 @@ impl<T: Primitive> FromColor<Rgba<T>> for Luma<T> {
     }
 }
 
-impl<T: Primitive> FromColor<Rgb<T>> for Luma<T> {
+impl<T: Primitive + 'static> FromColor<Rgb<T>> for Luma<T> {
     fn from_color(&mut self, other: &Rgb<T>) {
             let gray = self.channels_mut();
             let rgb = other.channels();
@@ -268,7 +268,7 @@ impl<T: Primitive> FromColor<Rgb<T>> for Luma<T> {
     }
 }
 
-impl<T: Primitive> FromColor<LumaA<T>> for Luma<T> {
+impl<T: Primitive + 'static> FromColor<LumaA<T>> for Luma<T> {
     fn from_color(&mut self, other: &LumaA<T>) {
             self.channels_mut()[0] = other.channels()[0]
     }
@@ -277,7 +277,7 @@ impl<T: Primitive> FromColor<LumaA<T>> for Luma<T> {
 /// FromColor for LumA
 
 
-impl<T: Primitive> FromColor<Rgba<T>> for LumaA<T> {
+impl<T: Primitive + 'static> FromColor<Rgba<T>> for LumaA<T> {
     fn from_color(&mut self, other: &Rgba<T>) {
         let gray_a = self.channels_mut();
         let rgba = other.channels();
@@ -289,7 +289,7 @@ impl<T: Primitive> FromColor<Rgba<T>> for LumaA<T> {
     }
 }
 
-impl<T: Primitive> FromColor<Rgb<T>> for LumaA<T> {
+impl<T: Primitive + 'static> FromColor<Rgb<T>> for LumaA<T> {
     fn from_color(&mut self, other: &Rgb<T>) {
         let gray_a = self.channels_mut();
         let rgb = other.channels();
@@ -301,7 +301,7 @@ impl<T: Primitive> FromColor<Rgb<T>> for LumaA<T> {
     }
 }
 
-impl<T: Primitive> FromColor<Luma<T>> for LumaA<T> {
+impl<T: Primitive + 'static> FromColor<Luma<T>> for LumaA<T> {
     fn from_color(&mut self, other: &Luma<T>) {
         let gray_a = self.channels_mut();
         gray_a[0] = other.channels()[0];
@@ -311,7 +311,7 @@ impl<T: Primitive> FromColor<Luma<T>> for LumaA<T> {
 
 /// FromColor for RGBA
 
-impl<T: Primitive> FromColor<Rgb<T>> for Rgba<T> {
+impl<T: Primitive + 'static> FromColor<Rgb<T>> for Rgba<T> {
     fn from_color(&mut self, other: &Rgb<T>) {
         let rgba = self.channels_mut();
         let rgb = other.channels();
@@ -323,7 +323,7 @@ impl<T: Primitive> FromColor<Rgb<T>> for Rgba<T> {
     }
 }
 
-impl<T: Primitive> FromColor<LumaA<T>> for Rgba<T> {
+impl<T: Primitive + 'static> FromColor<LumaA<T>> for Rgba<T> {
     fn from_color(&mut self, other: &LumaA<T>) {
         let rgba = self.channels_mut();
         let gray = other.channels();
@@ -334,7 +334,7 @@ impl<T: Primitive> FromColor<LumaA<T>> for Rgba<T> {
     }
 }
 
-impl<T: Primitive> FromColor<Luma<T>> for Rgba<T> {
+impl<T: Primitive + 'static> FromColor<Luma<T>> for Rgba<T> {
     fn from_color(&mut self, gray: &Luma<T>) {
         let rgba = self.channels_mut();
         let gray = gray.channels()[0];
@@ -348,7 +348,7 @@ impl<T: Primitive> FromColor<Luma<T>> for Rgba<T> {
 
 /// FromColor for RGB
 
-impl<T: Primitive> FromColor<Rgba<T>> for Rgb<T> {
+impl<T: Primitive + 'static> FromColor<Rgba<T>> for Rgb<T> {
     fn from_color(&mut self, other: &Rgba<T>) {
         let rgb = self.channels_mut();
         let rgba = other.channels();
@@ -359,7 +359,7 @@ impl<T: Primitive> FromColor<Rgba<T>> for Rgb<T> {
     }
 }
 
-impl<T: Primitive> FromColor<LumaA<T>> for Rgb<T> {
+impl<T: Primitive + 'static> FromColor<LumaA<T>> for Rgb<T> {
     fn from_color(&mut self, other: &LumaA<T>) {
         let rgb = self.channels_mut();
         let gray = other.channels()[0];
@@ -369,7 +369,7 @@ impl<T: Primitive> FromColor<LumaA<T>> for Rgb<T> {
     }
 }
 
-impl<T: Primitive> FromColor<Luma<T>> for Rgb<T> {
+impl<T: Primitive + 'static> FromColor<Luma<T>> for Rgb<T> {
     fn from_color(&mut self, gray: &Luma<T>) {
         let rgb = self.channels_mut();
         let gray = gray.channels()[0];

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -346,7 +346,9 @@ impl DynamicImage {
 }
 
 #[allow(deprecated)]
-impl GenericImage<color::Rgba<u8>> for DynamicImage {
+impl GenericImage for DynamicImage {
+    type Pixel = color::Rgba<u8>;
+
     fn dimensions(&self) -> (u32, u32) {
         dynamic_map!(*self, ref p -> p.dimensions())
     }

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -315,7 +315,7 @@ impl<R: Reader> ImageDecoder for GIFDecoder<R> {
                         overlay(&mut canvas, &buffer, left, top);
                     }
                 }
-                Ok(DecodingResult::U8(canvas.into_vec()))
+                Ok(DecodingResult::U8(canvas.into_raw()))
             },
             None => Err(ImageError::ImageEnd)
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -344,7 +344,7 @@ impl<'a, P: Pixel + 'static, I: GenericImage<P>> SubImage<'a, I>
     }
 
     /// Convert this subimage to an ImageBuffer
-    pub fn to_image(&self) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> {
+    pub fn to_image(&self) -> ImageBuffer<P, Vec<P::Subpixel>> {
         let mut out = ImageBuffer::new(self.xstride, self.ystride);
 
         for y in (0..self.ystride) {

--- a/src/image.rs
+++ b/src/image.rs
@@ -241,7 +241,7 @@ impl<'a, I: GenericImage + 'a> Iterator for MutPixels<'a, I>
 /// A trait for manipulating images.
 pub trait GenericImage: Sized {
     /// The type of pixel.
-    type Pixel: Pixel;
+    type Pixel: Pixel + 'static;
 
     /// The width and height of this image.
     fn dimensions(&self) -> (u32, u32);
@@ -317,7 +317,7 @@ pub struct SubImage <'a, I: 'a> {
     ystride: u32,
 }
 
-impl<'a, I: GenericImage> SubImage<'a, I>
+impl<'a, I: GenericImage + 'a> SubImage<'a, I>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 
@@ -361,9 +361,10 @@ impl<'a, I: GenericImage> SubImage<'a, I>
 }
 
 #[allow(deprecated)]
-impl<'a, I: GenericImage + 'a> GenericImage for SubImage<'a, I>
-    where I::Pixel: 'a,
-          <I::Pixel as Pixel>::Subpixel: 'a {
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+impl<'a, I: GenericImage + 'static> GenericImage for SubImage<'a, I>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     type Pixel = I::Pixel;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -175,7 +175,9 @@ pub struct Pixels<'a, I:'a> {
 }
 
 #[old_impl_check]
-impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> Iterator for Pixels<'a, I> {
+impl<'a, P: Pixel, I: GenericImage<P>> Iterator for Pixels<'a, I>
+    where P::Subpixel: Primitive {
+
     type Item = (u32, u32, P);
     fn next(&mut self) -> Option<(u32, u32, P)> {
         if self.x >= self.width {
@@ -207,7 +209,9 @@ pub struct MutPixels<'a, I:'a> {
 }
 
 #[old_impl_check]
-impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> Iterator for MutPixels<'a, I> {
+impl<'a, P: Pixel, I: GenericImage<P>> Iterator for MutPixels<'a, I>
+    where P::Subpixel: Primitive {
+
     type Item = (u32, u32, &'a mut P);
     fn next(&mut self) -> Option<(u32, u32, &'a mut P)> {
         if self.x >= self.width {
@@ -312,7 +316,9 @@ pub struct SubImage <'a, I:'a> {
 }
 
 #[old_impl_check]
-impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubImage<'a, I> {
+impl<'a, P: Pixel + 'static, I: GenericImage<P>> SubImage<'a, I>
+    where P::Subpixel: Primitive + 'static {
+
     /// Construct a new subimage
     pub fn new(image: &mut I, x: u32, y: u32, width: u32, height: u32) -> SubImage<I> {
         SubImage {
@@ -338,7 +344,7 @@ impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubI
     }
 
     /// Convert this subimage to an ImageBuffer
-    pub fn to_image(&self) -> ImageBuffer<Vec<T>, T, P> {
+    pub fn to_image(&self) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> {
         let mut out = ImageBuffer::new(self.xstride, self.ystride);
 
         for y in (0..self.ystride) {
@@ -354,7 +360,9 @@ impl<'a, T: Primitive + 'static, P: Pixel<T> + 'static, I: GenericImage<P>> SubI
 
 #[allow(deprecated)]
 #[old_impl_check]
-impl<'a, T: Primitive, P: Pixel<T>, I: GenericImage<P>> GenericImage<P> for SubImage<'a, I> {
+impl<'a, P: Pixel, I: GenericImage<P>> GenericImage<P> for SubImage<'a, I>
+    where P::Subpixel: Primitive {
+
     fn dimensions(&self) -> (u32, u32) {
         (self.xstride, self.ystride)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -241,7 +241,7 @@ impl<'a, I: GenericImage + 'a> Iterator for MutPixels<'a, I>
 /// A trait for manipulating images.
 pub trait GenericImage: Sized {
     /// The type of pixel.
-    type Pixel: Pixel + 'static;
+    type Pixel: Pixel;
 
     /// The width and height of this image.
     fn dimensions(&self) -> (u32, u32);
@@ -317,7 +317,8 @@ pub struct SubImage <'a, I: 'a> {
     ystride: u32,
 }
 
-impl<'a, I: GenericImage + 'a> SubImage<'a, I>
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+impl<'a, I: GenericImage + 'static> SubImage<'a, I>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -4,8 +4,10 @@ use buffer::{ImageBuffer, Pixel};
 use image::GenericImage;
 
 /// Rotate an image 90 degrees clockwise.
-pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
+pub fn rotate90<I: GenericImage>(image:  &I)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -20,8 +22,10 @@ pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 }
 
 /// Rotate an image 180 degrees clockwise.
-pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
+pub fn rotate180<I: GenericImage>(image:  &I)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
@@ -36,8 +40,10 @@ pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 }
 
 /// Rotate an image 270 degrees clockwise.
-pub fn rotate270<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
+pub fn rotate270<I: GenericImage>(image:  &I)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -52,8 +58,10 @@ pub fn rotate270<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 }
 
 /// Flip an image horizontally
-pub fn flip_horizontal<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
+pub fn flip_horizontal<I: GenericImage>(image:  &I)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -68,8 +76,10 @@ pub fn flip_horizontal<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 }
 
 /// Flip an image vertically
-pub fn flip_vertical<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
+pub fn flip_vertical<I: GenericImage>(image:  &I)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,11 +1,7 @@
 //! Functions for performing affine transformations.
 
-use buffer::Pixel;
-use traits::Primitive;
-use image:: {
-    GenericImage,
-};
-use buffer::ImageBuffer;
+use buffer::{ImageBuffer, Pixel};
+use image::GenericImage;
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
@@ -26,7 +22,6 @@ pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 /// Rotate an image 180 degrees clockwise.
 pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
     -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
-    let (width, height) = image.dimensions();
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -4,7 +4,8 @@ use buffer::{ImageBuffer, Pixel};
 use image::GenericImage;
 
 /// Rotate an image 90 degrees clockwise.
-pub fn rotate90<I: GenericImage>(image:  &I)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn rotate90<I: GenericImage + 'static>(image:  &I)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -22,7 +23,8 @@ pub fn rotate90<I: GenericImage>(image:  &I)
 }
 
 /// Rotate an image 180 degrees clockwise.
-pub fn rotate180<I: GenericImage>(image:  &I)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn rotate180<I: GenericImage + 'static>(image:  &I)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -40,7 +42,8 @@ pub fn rotate180<I: GenericImage>(image:  &I)
 }
 
 /// Rotate an image 270 degrees clockwise.
-pub fn rotate270<I: GenericImage>(image:  &I)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn rotate270<I: GenericImage + 'static>(image:  &I)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -58,7 +61,8 @@ pub fn rotate270<I: GenericImage>(image:  &I)
 }
 
 /// Flip an image horizontally
-pub fn flip_horizontal<I: GenericImage>(image:  &I)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn flip_horizontal<I: GenericImage + 'static>(image:  &I)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -76,7 +80,8 @@ pub fn flip_horizontal<I: GenericImage>(image:  &I)
 }
 
 /// Flip an image vertically
-pub fn flip_vertical<I: GenericImage>(image:  &I)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn flip_vertical<I: GenericImage + 'static>(image:  &I)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -9,7 +9,7 @@ use buffer::ImageBuffer;
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -25,7 +25,7 @@ pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 
 /// Rotate an image 180 degrees clockwise.
 pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -42,7 +42,7 @@ pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 
 /// Rotate an image 270 degrees clockwise.
 pub fn rotate270<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -58,7 +58,7 @@ pub fn rotate270<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 
 /// Flip an image horizontally
 pub fn flip_horizontal<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -74,7 +74,7 @@ pub fn flip_horizontal<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
 
 /// Flip an image vertically
 pub fn flip_vertical<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    -> ImageBuffer<P, Vec<P::Subpixel>> where P::Subpixel: 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -8,7 +8,8 @@ use image:: {
 use buffer::ImageBuffer;
 
 /// Rotate an image 90 degrees clockwise.
-pub fn rotate90<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(image:  &I) -> ImageBuffer<Vec<P>, P, T> {
+pub fn rotate90<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -23,7 +24,9 @@ pub fn rotate90<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
 }
 
 /// Rotate an image 180 degrees clockwise.
-pub fn rotate180<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(image:  &I) -> ImageBuffer<Vec<P>, P, T> {
+pub fn rotate180<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
+    let (width, height) = image.dimensions();
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
@@ -38,7 +41,8 @@ pub fn rotate180<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
 }
 
 /// Rotate an image 270 degrees clockwise.
-pub fn rotate270<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(image:  &I) -> ImageBuffer<Vec<P>, P, T> {
+pub fn rotate270<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -53,7 +57,8 @@ pub fn rotate270<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
 }
 
 /// Flip an image horizontally
-pub fn flip_horizontal<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(image:  &I) -> ImageBuffer<Vec<P>, P, T> {
+pub fn flip_horizontal<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
 
@@ -68,7 +73,8 @@ pub fn flip_horizontal<P: Primitive + 'static, T: Pixel<P> + 'static, I: Generic
 }
 
 /// Flip an image vertically
-pub fn flip_vertical<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(image:  &I) -> ImageBuffer<Vec<P>, P, T> {
+pub fn flip_vertical<P: Pixel + 'static, I: GenericImage<P>>(image:  &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P> where P::Subpixel: Primitive + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -18,7 +18,8 @@ fn clamp <N: PartialOrd> (a: N, min: N, max: N) -> N {
 }
 
 /// Convert the supplied image to grayscale
-pub fn grayscale<I: GenericImage>(image: &I)
+// TODO: is the 'static bound on `I` really required? Can we avoid it?
+pub fn grayscale<'a, I: GenericImage + 'static>(image: &I)
     -> ImageBuffer<Luma<<I::Pixel as Pixel>::Subpixel>, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: Default + 'static {

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -54,7 +54,8 @@ pub fn invert<I: GenericImage>(image: &mut I) {
 /// Adjust the contrast of the supplied image
 /// ```contrast``` is the amount to adjust the contrast by.
 /// Negative values decrease the contrast and positive values increase the contrast.
-pub fn contrast<I: GenericImage>(image: &I, contrast: f32)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+pub fn contrast<I: GenericImage + 'static>(image: &I, contrast: f32)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -62,7 +63,7 @@ pub fn contrast<I: GenericImage>(image: &I, contrast: f32)
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    let max = Primitive::max_value();
+    let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
     let max: f32 = cast(max).unwrap();
 
     let percent = ((100.0 + contrast) / 100.0).powi(2);
@@ -70,7 +71,7 @@ pub fn contrast<I: GenericImage>(image: &I, contrast: f32)
     for y in (0..height) {
         for x in (0..width) {
             let f = image.get_pixel(x, y).map(|&: b| {
-                let c = cast(b).unwrap();
+                let c: f32 = cast(b).unwrap();
 
                 let d = ((c / max - 0.5) * percent  + 0.5) * max;
                 let e = clamp(d, 0.0, max);
@@ -88,7 +89,8 @@ pub fn contrast<I: GenericImage>(image: &I, contrast: f32)
 /// Brighten the supplied image
 /// ```value``` is the amount to brighten each pixel by.
 /// Negative values decrease the brightness and positive values increase it.
-pub fn brighten<I: GenericImage>(image: &I, value: i32)
+// TODO: Is the 'static bound on `I` really required? Can we avoid it?
+pub fn brighten<I: GenericImage + 'static>(image: &I, value: i32)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -96,13 +98,13 @@ pub fn brighten<I: GenericImage>(image: &I, value: i32)
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    let max = Primitive::max_value();
+    let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
     let max: i32 = cast(max).unwrap();
 
     for y in (0..height) {
         for x in (0..width) {
             let e = image.get_pixel(x, y).map_with_alpha(|&:b| {
-                let c = cast(b).unwrap();
+                let c: i32 = cast(b).unwrap();
                 let d = clamp(c + value, 0, max);
 
                 cast(d).unwrap()

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -23,9 +23,9 @@ fn clamp <N: PartialOrd> (a: N, min: N, max: N) -> N {
 }
 
 /// Convert the supplied image to grayscale
-pub fn grayscale<P: Primitive + Default + 'static, T: Pixel<P> + 'static, I: GenericImage<T>> (
-    image: &I) -> ImageBuffer<Vec<P>, P, Luma<P>> {
-
+pub fn grayscale<P: Pixel + 'static, I: GenericImage<P>> (image: &I)
+    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, Luma<P::Subpixel>>
+    where P::Subpixel: Primitive + Default + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
@@ -41,7 +41,7 @@ pub fn grayscale<P: Primitive + Default + 'static, T: Pixel<P> + 'static, I: Gen
 
 /// Invert each pixel within the supplied image
 /// This function operates in place.
-pub fn invert<P: Primitive, T: Pixel<P>, I: GenericImage<T>>(image: &mut I) {
+pub fn invert<P: Pixel, I: GenericImage<P>>(image: &mut I) where P::Subpixel : Primitive {
     let (width, height) = image.dimensions();
 
     for y in (0..height) {
@@ -57,9 +57,10 @@ pub fn invert<P: Primitive, T: Pixel<P>, I: GenericImage<T>>(image: &mut I) {
 /// Adjust the contrast of the supplied image
 /// ```contrast``` is the amount to adjust the contrast by.
 /// Negative values decrease the contrast and positive values increase the contrast.
-pub fn contrast<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+pub fn contrast<P: Pixel + 'static, I: GenericImage<P>>(
     image:    &I,
-    contrast: f32) -> ImageBuffer<Vec<P>, P, T> {
+    contrast: f32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -90,9 +91,10 @@ pub fn contrast<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T
 /// Brighten the supplied image
 /// ```value``` is the amount to brighten each pixel by.
 /// Negative values decrease the brightness and positive values increase it.
-pub fn brighten<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+pub fn brighten<P: Pixel + 'static, I: GenericImage<P>>(
     image: &I,
-    value: i32) -> ImageBuffer<Vec<P>, P, T> {
+    value: i32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -24,8 +24,8 @@ fn clamp <N: PartialOrd> (a: N, min: N, max: N) -> N {
 
 /// Convert the supplied image to grayscale
 pub fn grayscale<P: Pixel + 'static, I: GenericImage<P>> (image: &I)
-    -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, Luma<P::Subpixel>>
-    where P::Subpixel: Primitive + Default + 'static {
+    -> ImageBuffer<Luma<P::Subpixel>, Vec<P::Subpixel>>
+    where P::Subpixel: Default + 'static {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
@@ -59,8 +59,8 @@ pub fn invert<P: Pixel, I: GenericImage<P>>(image: &mut I) where P::Subpixel : P
 /// Negative values decrease the contrast and positive values increase the contrast.
 pub fn contrast<P: Pixel + 'static, I: GenericImage<P>>(
     image:    &I,
-    contrast: f32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    contrast: f32) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -93,8 +93,8 @@ pub fn contrast<P: Pixel + 'static, I: GenericImage<P>>(
 /// Negative values decrease the brightness and positive values increase it.
 pub fn brighten<P: Pixel + 'static, I: GenericImage<P>>(
     image: &I,
-    value: i32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    value: i32) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -65,20 +65,20 @@ pub fn contrast<P: Pixel + 'static, I: GenericImage<P>>(
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    let max:P = Primitive::max_value();
-    let max = cast::<P, f32>(max).unwrap();
+    let max: P::Subpixel = Primitive::max_value();
+    let max = cast::<P::Subpixel, f32>(max).unwrap();
 
     let percent = ((100.0 + contrast) / 100.0).powi(2);
 
     for y in (0..height) {
         for x in (0..width) {
             let f = image.get_pixel(x, y).map(|&: b| {
-                let c = cast::<P, f32>(b).unwrap();
+                let c = cast::<P::Subpixel, f32>(b).unwrap();
 
                 let d = ((c / max - 0.5) * percent  + 0.5) * max;
                 let e = clamp(d, 0.0, max);
 
-                cast::<f32, P>(e).unwrap()
+                cast::<f32, P::Subpixel>(e).unwrap()
             });
 
             out.put_pixel(x, y, f);
@@ -99,16 +99,16 @@ pub fn brighten<P: Pixel + 'static, I: GenericImage<P>>(
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    let max: P = Primitive::max_value();
-    let max = cast::<P, i32>(max).unwrap();
+    let max: P::Subpixel = Primitive::max_value();
+    let max = cast::<P::Subpixel, i32>(max).unwrap();
 
     for y in (0..height) {
         for x in (0..width) {
             let e = image.get_pixel(x, y).map_with_alpha(|&:b| {
-                let c = cast::<P, i32>(b).unwrap();
+                let c = cast::<P::Subpixel, i32>(b).unwrap();
                 let d = clamp(c + value, 0, max);
 
-                cast::<i32, P>(d).unwrap()
+                cast::<i32, P::Subpixel>(d).unwrap()
             }, |&:alpha| alpha);
 
             out.put_pixel(x, y, e);

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -51,8 +51,8 @@ mod sample;
 /// Return a mutable view into an image
 // TODO: Is a 'static bound on `I` really required? Acn we avoid it?
 pub fn crop<I: GenericImage + 'static>(image: &mut I, x: u32, y: u32,
-                             width: u32, height: u32)
-                             -> SubImage<I>
+                                       width: u32, height: u32)
+                                       -> SubImage<I>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -49,12 +49,13 @@ mod colorops;
 mod sample;
 
 /// Return a mutable view into an image
-pub fn crop<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+pub fn crop<P: Pixel + 'static, I: GenericImage<P>>(
     image:  &mut I,
     x: u32,
     y: u32,
     width: u32,
-    height: u32) -> SubImage<I> {
+    height: u32) -> SubImage<I>
+    where P::Subpixel: Primitive + 'static {
 
     let (iwidth, iheight) = image.dimensions();
 
@@ -68,11 +69,12 @@ pub fn crop<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
 }
 
 /// Overlay an image at a given coordinate (x, y)
-pub fn overlay<P: Primitive, T: Pixel<P>, I: GenericImage<T>>(
+pub fn overlay<P: Pixel, I: GenericImage<P>>(
     bottom: &mut I,
     top: &I,
     x: u32,
-    y: u32)  {
+    y: u32)
+    where P::Subpixel: Primitive {
     let (top_width, top_height) = top.dimensions();
     let (bottom_width, bottom_height) = bottom.dimensions();
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -49,13 +49,11 @@ mod colorops;
 mod sample;
 
 /// Return a mutable view into an image
-pub fn crop<P: Pixel + 'static, I: GenericImage<P>>(
-    image:  &mut I,
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32) -> SubImage<I>
-    where P::Subpixel: Primitive + 'static {
+pub fn crop<I: GenericImage>(image: &mut I, x: u32, y: u32,
+                             width: u32, height: u32)
+                             -> SubImage<I>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let (iwidth, iheight) = image.dimensions();
 
@@ -69,12 +67,7 @@ pub fn crop<P: Pixel + 'static, I: GenericImage<P>>(
 }
 
 /// Overlay an image at a given coordinate (x, y)
-pub fn overlay<P: Pixel, I: GenericImage<P>>(
-    bottom: &mut I,
-    top: &I,
-    x: u32,
-    y: u32)
-    where P::Subpixel: Primitive {
+pub fn overlay<I: GenericImage>(bottom: &mut I, top: &I, x: u32, y:u32) {
     let (top_width, top_height) = top.dimensions();
     let (bottom_width, bottom_height) = bottom.dimensions();
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -49,7 +49,8 @@ mod colorops;
 mod sample;
 
 /// Return a mutable view into an image
-pub fn crop<I: GenericImage>(image: &mut I, x: u32, y: u32,
+// TODO: Is a 'static bound on `I` really required? Acn we avoid it?
+pub fn crop<I: GenericImage + 'static>(image: &mut I, x: u32, y: u32,
                              width: u32, height: u32)
                              -> SubImage<I>
     where I::Pixel: 'static,

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -143,10 +143,11 @@ fn clamp<N: PartialOrd>(a: N, min: N, max: N) -> N {
 // The height of the image remains unchanged.
 // ```new_width``` is the desired width of the new image
 // ```filter``` is the filter to use for sampling.
-fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
     image:     &I,
     new_width: u32,
-    filter:    &mut Filter) -> ImageBuffer<Vec<P>, P, T> {
+    filter:    &mut Filter) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(new_width, height);
@@ -212,11 +213,11 @@ fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
             t3 /= sum;
             t4 /= sum;
 
-            let t: T = Pixel::from_channels(
-                cast::<f32, P>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t4, 0.0, max)).unwrap()
+            let t: P = Pixel::from_channels(
+                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(outx, y, t);
@@ -230,10 +231,11 @@ fn horizontal_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericIm
 // The width of the image remains unchanged.
 // ```new_height``` is the desired height of the new image
 // ```filter``` is the filter to use for sampling.
-fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
     image:      &I,
     new_height: u32,
-    filter:     &mut Filter) -> ImageBuffer<Vec<P>, P, T> {
+    filter:     &mut Filter) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static{
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, new_height);
@@ -299,11 +301,11 @@ fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImag
             t3 /= sum;
             t4 /= sum;
 
-            let t: T = Pixel::from_channels(
-                cast::<f32, P>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t4, 0.0, max)).unwrap()
+            let t: P = Pixel::from_channels(
+                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(x, outy, t);
@@ -315,9 +317,10 @@ fn vertical_sample<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImag
 
 /// Perform a 3x3 box filter on the supplied image.
 /// ```kernel``` is an array of the filter weights of length 9.
-pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<T>>(
+pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
     image:  &I,
-    kernel: &[f32]) -> ImageBuffer<Vec<P>, P, T> {
+    kernel: &[f32]) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     // The kernel's input positions relative to the current pixel.
     let taps: &[(isize, isize)] = &[
@@ -381,11 +384,11 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
             t3 /= sum;
             t4 /= sum;
 
-            let t: T = Pixel::from_channels(
-                cast::<f32, P>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P>(clamp(t4, 0.0, max)).unwrap()
+            let t: P = Pixel::from_channels(
+                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
+                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(x, y, t);
@@ -398,11 +401,12 @@ pub fn filter3x3<P: Primitive + 'static, T: Pixel<P> + 'static, I: GenericImage<
 /// Resize the supplied image to the specified dimensions
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-pub fn resize<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
+pub fn resize<P: Pixel + 'static, I: GenericImage<P>>(
     image:   &I,
     nwidth:  u32,
     nheight: u32,
-    filter:  FilterType) -> ImageBuffer<Vec<A>, A, T> {
+    filter:  FilterType) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let mut method = match filter {
         FilterType::Nearest    =>   Filter {
@@ -433,9 +437,10 @@ pub fn resize<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>
 
 /// Performs a Gaussian blur on the supplied image.
 /// ```sigma``` is a measure of how much to blur by.
-pub fn blur<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
+pub fn blur<P: Pixel + 'static, I: GenericImage<P>>(
     image:  &I,
-    sigma:  f32) -> ImageBuffer<Vec<A>, A, T> {
+    sigma:  f32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let sigma = if sigma < 0.0 {
         1.0
@@ -460,14 +465,15 @@ pub fn blur<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
 /// ```sigma``` is the amount to blur the image by.
 /// ```threshold``` is the threshold for the difference between
 /// see https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
-pub fn unsharpen<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<T>>(
+pub fn unsharpen<P: Pixel + 'static, I: GenericImage<P>>(
     image:     &I,
     sigma:     f32,
-    threshold: i32) -> ImageBuffer<Vec<A>, A, T> {
+    threshold: i32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    where P::Subpixel: Primitive + 'static {
 
     let mut tmp = blur(image, sigma);
 
-    let max: A = Primitive::max_value();
+    let max: P::Subpixel = Primitive::max_value();
     let (width, height) = image.dimensions();
 
     for y in (0..height) {
@@ -476,15 +482,15 @@ pub fn unsharpen<A: Primitive + 'static, T: Pixel<A> + 'static, I: GenericImage<
             let b = tmp.get_pixel_mut(x, y);
 
             let p = a.map2(b, |&: c, d| {
-                let ic = cast::<A, i32>(c).unwrap();
-                let id = cast::<A, i32>(d).unwrap();
+                let ic = cast::<P::Subpixel, i32>(c).unwrap();
+                let id = cast::<P::Subpixel, i32>(d).unwrap();
 
                 let diff = (ic - id).abs();
 
                 if diff > threshold {
-                let e = clamp(ic + diff, 0, cast::<A, i32>(max).unwrap());
+                let e = clamp(ic + diff, 0, cast::<P::Subpixel, i32>(max).unwrap());
 
-                    cast::<i32, A>(e).unwrap()
+                    cast::<i32, P::Subpixel>(e).unwrap()
                 } else {
                     c
                 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -11,13 +11,9 @@ use std::num:: {
     SignedInt,
 };
 
-use buffer::Pixel;
+use buffer::{ImageBuffer, Pixel};
 use traits::Primitive;
-
-use image:: {
-    GenericImage,
-};
-use buffer::ImageBuffer;
+use image::GenericImage;
 
 /// Available Sampling Filters
 #[derive(Copy)]
@@ -143,18 +139,18 @@ fn clamp<N: PartialOrd>(a: N, min: N, max: N) -> N {
 // The height of the image remains unchanged.
 // ```new_width``` is the desired width of the new image
 // ```filter``` is the filter to use for sampling.
-fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
-    image:     &I,
-    new_width: u32,
-    filter:    &mut Filter) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: 'static {
+fn horizontal_sample<I: GenericImage>(image: &I, new_width: u32,
+                                      filter: &mut Filter)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(new_width, height);
 
     for y in (0..height) {
-        let max: P::Subpixel = Primitive::max_value();
-        let max = cast::<P::Subpixel, f32>(max).unwrap();
+        let max = Primitive::max_value();
+        let max: f32 = cast(max).unwrap();
 
         let ratio = width as f32 / new_width as f32;
 
@@ -192,11 +188,11 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
                 let p = image.get_pixel(x0, y);
 
                 let (k1, k2, k3, k4) = p.channels4();
-                let (a, b, c, d) = (
-                    cast::<P::Subpixel, f32>(k1).unwrap(),
-                    cast::<P::Subpixel, f32>(k2).unwrap(),
-                    cast::<P::Subpixel, f32>(k3).unwrap(),
-                    cast::<P::Subpixel, f32>(k4).unwrap()
+                let (a, b, c, d): (f32, f32, f32, f32) = (
+                    cast(k1).unwrap(),
+                    cast(k2).unwrap(),
+                    cast(k3).unwrap(),
+                    cast(k4).unwrap()
                 );
 
                 let (a1, b1, c1, d1) = ( a  * w,  b * w,   c * w,   d * w);
@@ -213,11 +209,11 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
             t3 /= sum;
             t4 /= sum;
 
-            let t: P = Pixel::from_channels(
-                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
+            let t = Pixel::from_channels(
+                cast(clamp(t1, 0.0, max)).unwrap(),
+                cast(clamp(t2, 0.0, max)).unwrap(),
+                cast(clamp(t3, 0.0, max)).unwrap(),
+                cast(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(outx, y, t);
@@ -231,19 +227,19 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
 // The width of the image remains unchanged.
 // ```new_height``` is the desired height of the new image
 // ```filter``` is the filter to use for sampling.
-fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
-    image:      &I,
-    new_height: u32,
-    filter:     &mut Filter) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: 'static{
+fn vertical_sample<I: GenericImage>(image: &I, new_height: u32,
+                                    filter: &mut Filter)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, new_height);
 
 
     for x in (0..width) {
-        let max: P::Subpixel = Primitive::max_value();
-        let max = cast::<P::Subpixel, f32>(max).unwrap();
+        let max = Primitive::max_value();
+        let max: f32 = cast(max).unwrap();
 
         let ratio = height as f32 / new_height as f32;
 
@@ -280,11 +276,11 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
                 let p = image.get_pixel(x, y0);
 
                 let (k1, k2, k3, k4) = p.channels4();
-                let (a, b, c, d) = (
-                    cast::<P::Subpixel, f32>(k1).unwrap(),
-                    cast::<P::Subpixel, f32>(k2).unwrap(),
-                    cast::<P::Subpixel, f32>(k3).unwrap(),
-                    cast::<P::Subpixel, f32>(k4).unwrap()
+                let (a, b, c, d): (f32, f32, f32, f32) = (
+                    cast(k1).unwrap(),
+                    cast(k2).unwrap(),
+                    cast(k3).unwrap(),
+                    cast(k4).unwrap()
                 );
 
                 let (a1, b1, c1, d1) = ( a  * w,  b * w,   c * w,   d * w);
@@ -301,11 +297,11 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
             t3 /= sum;
             t4 /= sum;
 
-            let t: P = Pixel::from_channels(
-                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
+            let t = Pixel::from_channels(
+                cast(clamp(t1, 0.0, max)).unwrap(),
+                cast(clamp(t2, 0.0, max)).unwrap(),
+                cast(clamp(t3, 0.0, max)).unwrap(),
+                cast(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(x, outy, t);
@@ -317,10 +313,10 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
 
 /// Perform a 3x3 box filter on the supplied image.
 /// ```kernel``` is an array of the filter weights of length 9.
-pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
-    image:  &I,
-    kernel: &[f32]) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: 'static {
+pub fn filter3x3<I: GenericImage>(image: &I, kernel: &[f32])
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     // The kernel's input positions relative to the current pixel.
     let taps: &[(isize, isize)] = &[
@@ -334,9 +330,8 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
     let mut out = ImageBuffer::new(width, height);
 
 
-    let max:
-    P::Subpixel = Primitive::max_value();
-    let max = cast::<P::Subpixel, f32>(max).unwrap();
+    let max = Primitive::max_value();
+    let max: f32 = cast(max).unwrap();
 
     let sum = kernel.iter().fold(0.0, |&: a, f| a + *f);
 
@@ -364,12 +359,12 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
 
                 let (k1, k2, k3, k4) = p.channels4();
 
-                let (a, b, c, d) = (
-                                       cast::<P::Subpixel, f32>(k1).unwrap(),
-                                       cast::<P::Subpixel, f32>(k2).unwrap(),
-                                       cast::<P::Subpixel, f32>(k3).unwrap(),
-                                       cast::<P::Subpixel, f32>(k4).unwrap()
-                                   );
+                let (a, b, c, d): (f32, f32, f32, f32) = (
+                    cast(k1).unwrap(),
+                    cast(k2).unwrap(),
+                    cast(k3).unwrap(),
+                    cast(k4).unwrap()
+                );
 
                 let (a1, b1, c1, d1) = (a * k, b * k, c * k, d * k);
 
@@ -384,11 +379,11 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
             t3 /= sum;
             t4 /= sum;
 
-            let t: P = Pixel::from_channels(
-                cast::<f32, P::Subpixel>(clamp(t1, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t2, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t3, 0.0, max)).unwrap(),
-                cast::<f32, P::Subpixel>(clamp(t4, 0.0, max)).unwrap()
+            let t = Pixel::from_channels(
+                cast(clamp(t1, 0.0, max)).unwrap(),
+                cast(clamp(t2, 0.0, max)).unwrap(),
+                cast(clamp(t3, 0.0, max)).unwrap(),
+                cast(clamp(t4, 0.0, max)).unwrap()
             );
 
             out.put_pixel(x, y, t);
@@ -401,12 +396,11 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
 /// Resize the supplied image to the specified dimensions
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-pub fn resize<P: Pixel + 'static, I: GenericImage<P>>(
-    image:   &I,
-    nwidth:  u32,
-    nheight: u32,
-    filter:  FilterType) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: 'static {
+pub fn resize<I: GenericImage>(image: &I, nwidth: u32, nheight: u32,
+                               filter: FilterType)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let mut method = match filter {
         FilterType::Nearest    =>   Filter {
@@ -437,10 +431,10 @@ pub fn resize<P: Pixel + 'static, I: GenericImage<P>>(
 
 /// Performs a Gaussian blur on the supplied image.
 /// ```sigma``` is a measure of how much to blur by.
-pub fn blur<P: Pixel + 'static, I: GenericImage<P>>(
-    image:  &I,
-    sigma:  f32) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: 'static {
+pub fn blur<I: GenericImage>(image: &I, sigma: f32)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let sigma = if sigma < 0.0 {
         1.0
@@ -465,15 +459,15 @@ pub fn blur<P: Pixel + 'static, I: GenericImage<P>>(
 /// ```sigma``` is the amount to blur the image by.
 /// ```threshold``` is the threshold for the difference between
 /// see https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
-pub fn unsharpen<P: Pixel + 'static, I: GenericImage<P>>(
-    image:     &I,
-    sigma:     f32,
-    threshold: i32) -> ImageBuffer<P, Vec<P::Subpixel>>
-    where P::Subpixel: Primitive + 'static {
+pub fn unsharpen<I: GenericImage>(image: &I, sigma: f32, threshold: i32)
+    -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+    where I::Pixel: 'static,
+          <I::Pixel as Pixel>::Subpixel: 'static {
 
     let mut tmp = blur(image, sigma);
 
-    let max: P::Subpixel = Primitive::max_value();
+    let max = Primitive::max_value();
+    let max: i32 = cast(max).unwrap();
     let (width, height) = image.dimensions();
 
     for y in (0..height) {
@@ -482,15 +476,15 @@ pub fn unsharpen<P: Pixel + 'static, I: GenericImage<P>>(
             let b = tmp.get_pixel_mut(x, y);
 
             let p = a.map2(b, |&: c, d| {
-                let ic = cast::<P::Subpixel, i32>(c).unwrap();
-                let id = cast::<P::Subpixel, i32>(d).unwrap();
+                let ic: i32 = cast(c).unwrap();
+                let id: i32 = cast(d).unwrap();
 
                 let diff = (ic - id).abs();
 
                 if diff > threshold {
-                let e = clamp(ic + diff, 0, cast::<P::Subpixel, i32>(max).unwrap());
+                let e = clamp(ic + diff, 0, max);
 
-                    cast::<i32, P::Subpixel>(e).unwrap()
+                    cast(e).unwrap()
                 } else {
                     c
                 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -139,8 +139,9 @@ fn clamp<N: PartialOrd>(a: N, min: N, max: N) -> N {
 // The height of the image remains unchanged.
 // ```new_width``` is the desired width of the new image
 // ```filter``` is the filter to use for sampling.
-fn horizontal_sample<I: GenericImage>(image: &I, new_width: u32,
-                                      filter: &mut Filter)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+fn horizontal_sample<I: GenericImage + 'static>(image: &I, new_width: u32,
+                                                filter: &mut Filter)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -149,7 +150,7 @@ fn horizontal_sample<I: GenericImage>(image: &I, new_width: u32,
     let mut out = ImageBuffer::new(new_width, height);
 
     for y in (0..height) {
-        let max = Primitive::max_value();
+        let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
         let max: f32 = cast(max).unwrap();
 
         let ratio = width as f32 / new_width as f32;
@@ -227,8 +228,9 @@ fn horizontal_sample<I: GenericImage>(image: &I, new_width: u32,
 // The width of the image remains unchanged.
 // ```new_height``` is the desired height of the new image
 // ```filter``` is the filter to use for sampling.
-fn vertical_sample<I: GenericImage>(image: &I, new_height: u32,
-                                    filter: &mut Filter)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+fn vertical_sample<I: GenericImage + 'static>(image: &I, new_height: u32,
+                                              filter: &mut Filter)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -238,7 +240,7 @@ fn vertical_sample<I: GenericImage>(image: &I, new_height: u32,
 
 
     for x in (0..width) {
-        let max = Primitive::max_value();
+        let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
         let max: f32 = cast(max).unwrap();
 
         let ratio = height as f32 / new_height as f32;
@@ -313,7 +315,8 @@ fn vertical_sample<I: GenericImage>(image: &I, new_height: u32,
 
 /// Perform a 3x3 box filter on the supplied image.
 /// ```kernel``` is an array of the filter weights of length 9.
-pub fn filter3x3<I: GenericImage>(image: &I, kernel: &[f32])
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+pub fn filter3x3<I: GenericImage + 'static>(image: &I, kernel: &[f32])
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -329,8 +332,7 @@ pub fn filter3x3<I: GenericImage>(image: &I, kernel: &[f32])
 
     let mut out = ImageBuffer::new(width, height);
 
-
-    let max = Primitive::max_value();
+    let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
     let max: f32 = cast(max).unwrap();
 
     let sum = kernel.iter().fold(0.0, |&: a, f| a + *f);
@@ -396,8 +398,9 @@ pub fn filter3x3<I: GenericImage>(image: &I, kernel: &[f32])
 /// Resize the supplied image to the specified dimensions
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-pub fn resize<I: GenericImage>(image: &I, nwidth: u32, nheight: u32,
-                               filter: FilterType)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+pub fn resize<I: GenericImage + 'static>(image: &I, nwidth: u32, nheight: u32,
+                                         filter: FilterType)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -431,7 +434,8 @@ pub fn resize<I: GenericImage>(image: &I, nwidth: u32, nheight: u32,
 
 /// Performs a Gaussian blur on the supplied image.
 /// ```sigma``` is a measure of how much to blur by.
-pub fn blur<I: GenericImage>(image: &I, sigma: f32)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+pub fn blur<I: GenericImage + 'static>(image: &I, sigma: f32)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
@@ -459,14 +463,15 @@ pub fn blur<I: GenericImage>(image: &I, sigma: f32)
 /// ```sigma``` is the amount to blur the image by.
 /// ```threshold``` is the threshold for the difference between
 /// see https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
-pub fn unsharpen<I: GenericImage>(image: &I, sigma: f32, threshold: i32)
+// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
+pub fn unsharpen<I: GenericImage + 'static>(image: &I, sigma: f32, threshold: i32)
     -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 
     let mut tmp = blur(image, sigma);
 
-    let max = Primitive::max_value();
+    let max: <I::Pixel as Pixel>::Subpixel = Primitive::max_value();
     let max: i32 = cast(max).unwrap();
     let (width, height) = image.dimensions();
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -153,8 +153,8 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
     let mut out = ImageBuffer::new(new_width, height);
 
     for y in (0..height) {
-        let max: P = Primitive::max_value();
-        let max = cast::<P, f32>(max).unwrap();
+        let max: P::Subpixel = Primitive::max_value();
+        let max = cast::<P::Subpixel, f32>(max).unwrap();
 
         let ratio = width as f32 / new_width as f32;
 
@@ -193,10 +193,10 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
 
                 let (k1, k2, k3, k4) = p.channels4();
                 let (a, b, c, d) = (
-                    cast::<P, f32>(k1).unwrap(),
-                    cast::<P, f32>(k2).unwrap(),
-                    cast::<P, f32>(k3).unwrap(),
-                    cast::<P, f32>(k4).unwrap()
+                    cast::<P::Subpixel, f32>(k1).unwrap(),
+                    cast::<P::Subpixel, f32>(k2).unwrap(),
+                    cast::<P::Subpixel, f32>(k3).unwrap(),
+                    cast::<P::Subpixel, f32>(k4).unwrap()
                 );
 
                 let (a1, b1, c1, d1) = ( a  * w,  b * w,   c * w,   d * w);
@@ -242,8 +242,8 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
 
 
     for x in (0..width) {
-        let max: P = Primitive::max_value();
-        let max = cast::<P, f32>(max).unwrap();
+        let max: P::Subpixel = Primitive::max_value();
+        let max = cast::<P::Subpixel, f32>(max).unwrap();
 
         let ratio = height as f32 / new_height as f32;
 
@@ -281,10 +281,10 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
 
                 let (k1, k2, k3, k4) = p.channels4();
                 let (a, b, c, d) = (
-                    cast::<P, f32>(k1).unwrap(),
-                    cast::<P, f32>(k2).unwrap(),
-                    cast::<P, f32>(k3).unwrap(),
-                    cast::<P, f32>(k4).unwrap()
+                    cast::<P::Subpixel, f32>(k1).unwrap(),
+                    cast::<P::Subpixel, f32>(k2).unwrap(),
+                    cast::<P::Subpixel, f32>(k3).unwrap(),
+                    cast::<P::Subpixel, f32>(k4).unwrap()
                 );
 
                 let (a1, b1, c1, d1) = ( a  * w,  b * w,   c * w,   d * w);
@@ -335,8 +335,8 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
 
 
     let max:
-    P = Primitive::max_value();
-    let max = cast::<P, f32>(max).unwrap();
+    P::Subpixel = Primitive::max_value();
+    let max = cast::<P::Subpixel, f32>(max).unwrap();
 
     let sum = kernel.iter().fold(0.0, |&: a, f| a + *f);
 
@@ -365,10 +365,10 @@ pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
                 let (k1, k2, k3, k4) = p.channels4();
 
                 let (a, b, c, d) = (
-                                       cast::<P, f32>(k1).unwrap(),
-                                       cast::<P, f32>(k2).unwrap(),
-                                       cast::<P, f32>(k3).unwrap(),
-                                       cast::<P, f32>(k4).unwrap()
+                                       cast::<P::Subpixel, f32>(k1).unwrap(),
+                                       cast::<P::Subpixel, f32>(k2).unwrap(),
+                                       cast::<P::Subpixel, f32>(k3).unwrap(),
+                                       cast::<P::Subpixel, f32>(k4).unwrap()
                                    );
 
                 let (a1, b1, c1, d1) = (a * k, b * k, c * k, d * k);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -146,8 +146,8 @@ fn clamp<N: PartialOrd>(a: N, min: N, max: N) -> N {
 fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
     image:     &I,
     new_width: u32,
-    filter:    &mut Filter) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    filter:    &mut Filter) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(new_width, height);
@@ -234,8 +234,8 @@ fn horizontal_sample<P: Pixel + 'static, I: GenericImage<P>>(
 fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
     image:      &I,
     new_height: u32,
-    filter:     &mut Filter) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static{
+    filter:     &mut Filter) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static{
 
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, new_height);
@@ -319,8 +319,8 @@ fn vertical_sample<P: Pixel + 'static, I: GenericImage<P>>(
 /// ```kernel``` is an array of the filter weights of length 9.
 pub fn filter3x3<P: Pixel + 'static, I: GenericImage<P>>(
     image:  &I,
-    kernel: &[f32]) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    kernel: &[f32]) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     // The kernel's input positions relative to the current pixel.
     let taps: &[(isize, isize)] = &[
@@ -405,8 +405,8 @@ pub fn resize<P: Pixel + 'static, I: GenericImage<P>>(
     image:   &I,
     nwidth:  u32,
     nheight: u32,
-    filter:  FilterType) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    filter:  FilterType) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     let mut method = match filter {
         FilterType::Nearest    =>   Filter {
@@ -439,8 +439,8 @@ pub fn resize<P: Pixel + 'static, I: GenericImage<P>>(
 /// ```sigma``` is a measure of how much to blur by.
 pub fn blur<P: Pixel + 'static, I: GenericImage<P>>(
     image:  &I,
-    sigma:  f32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
-    where P::Subpixel: Primitive + 'static {
+    sigma:  f32) -> ImageBuffer<P, Vec<P::Subpixel>>
+    where P::Subpixel: 'static {
 
     let sigma = if sigma < 0.0 {
         1.0
@@ -468,7 +468,7 @@ pub fn blur<P: Pixel + 'static, I: GenericImage<P>>(
 pub fn unsharpen<P: Pixel + 'static, I: GenericImage<P>>(
     image:     &I,
     sigma:     f32,
-    threshold: i32) -> ImageBuffer<Vec<P::Subpixel>, P::Subpixel, P>
+    threshold: i32) -> ImageBuffer<P, Vec<P::Subpixel>>
     where P::Subpixel: Primitive + 'static {
 
     let mut tmp = blur(image, sigma);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(unused_typecasts)]
 #![deny(missing_copy_implementations)]
 // necessary for Primitive trait
-#![feature(old_orphan_check, old_impl_check)]
+#![feature(old_impl_check)]
 
 extern crate flate;
 extern crate num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 #![warn(unused_qualifications)]
 #![warn(unused_typecasts)]
 #![deny(missing_copy_implementations)]
-// necessary for Primitive trait
-#![feature(old_impl_check)]
 
 extern crate flate;
 extern crate num;


### PR DESCRIPTION
This still needs some cleanup, but this is going to be quite a big change, so I’m posting it here for early feedback. This resolves #240. There are a lot of breaking changes, so we might want to bump the version number when this can be merged.

- This uses associated types where appropriate. The most important changes are that the type parameters of `Pixel` and `GenericImage` are now associated types. `ImageBuffer` requires less type params.
- This resolves the `old_orphan_check` and `old_impl_check` warnings.

Associated types feel like the “right” way to go. In many places it simplifies the API, but naming the subpixel type has become uglier: for `I: GenericImage`, the subpixel type is `<I::Pixel as Pixel>::Subpixel`, instead of a `T` param that was often used before. However, the `T` param was often unconstrained, and there is no need for it with associated types.

A few issues:
- The return type of `into_dynamic` cannot be `ImageBuffer` any more. I removed the function.
- Many functions now require a `'static` bound on `I: GenericImage`. How will this impact users of the library, and is there a better way to do it?
- Should `Pixel::Subpixel` and `GenericImage::Pixel` have `'static` bounds? I had hoped that adding those would enable omitting the `where P::Subpixel: 'static` in most places, but unfortunately this is not the case.
- The pixel type was sometimes allowed to be unsized. What is the use of that?