### PR TITLE
Allow unstable code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(unused_qualifications)]
 #![warn(unused_typecasts)]
 #![deny(missing_copy_implementations)]
+#![allow(unstable)]
 // necessary for Primitive trait
 #![feature(old_orphan_check, old_impl_check)]
 


### PR DESCRIPTION
Since rust is no in alpha and a stable alternative does not always exists this lint is not helpful.

Should possibly be removed before Rust 1.0 release.