### PR TITLE
TypeId has moved to 'any' module

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,8 +1,7 @@
 use std::slice::{ Chunks, ChunksMut };
-use std::any::Any;
+use std::any::{ Any, TypeId };
 use std::ops::{ Index, IndexMut };
 use std::num::Int;
-use std::intrinsics::TypeId;
 use std::iter::repeat;
 
 use traits::{ Zero, Primitive };


### PR DESCRIPTION
TypeId now lives in 'any', rather than 'intrinsics' - this simple PR fixes it.