### PR TITLE
Fix IndexMut implementation for rustc 0b6dbbc

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -214,7 +214,6 @@ impl<T: Primitive> Index<usize> for $ident<T> {
 }
 
 impl<T: Primitive> IndexMut<usize> for $ident<T> {
-    type Output = T;
     #[inline(always)]
     fn index_mut<'a>(&'a mut self, _index: &usize) -> &'a mut T {
         let &mut $ident(ref mut this) = self;


### PR DESCRIPTION
[`rustc` 0b6dbbc9cfb747df1db646bba16561c022704056](https://github.com/rust-lang/rust/commit/0b6dbbc9cfb747df1db646bba16561c022704056) changed how `IndexMut` works; the `type Output = ..` bit is now redundant and can be removed from implementations.

With this change in place, `cargo build && cargo test` work again for:
```
$ rustc --version
rustc 1.0.0-nightly (74b874071 2015-02-08 00:24:03 +0000)
```