### PR TITLE
Add color quantizer

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -359,7 +359,7 @@ impl DynamicImage {
 
             image::ImageFormat::GIF => {
                 let mut g = gif::GIFEncoder::new(
-                    self.to_rgba(), None, gif::ColorMode::TrueColor
+                    self.to_rgba(), None, gif::ColorMode::Indexed(0xFF)
                 );
 
                 try!(g.encode(w));

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -6,11 +6,12 @@ use std::num:: {
 
 use std::default::Default;
 
-use color::Luma;
+use color::{Luma, Rgba};
 use buffer::{ImageBuffer, Pixel};
 use traits::Primitive;
 use image::GenericImage;
 use math::utils::clamp;
+use math::nq;
 
 /// Convert the supplied image to grayscale
 // TODO: is the 'static bound on `I` really required? Can we avoid it?
@@ -145,6 +146,20 @@ impl ColorMap for BiLevel {
         let new_color = 0xFF * self.index_of(color) as u8;
         let &mut Luma([ref mut luma]) = color;
         *luma = new_color;
+    }
+}
+
+impl ColorMap for nq::NeuQuant {
+    type Color = Rgba<u8>;
+
+    #[inline(always)]
+    fn index_of(&self, color: &Rgba<u8>) -> usize {
+        self.index_of(color.channels())
+    }
+
+    #[inline(always)]
+    fn map_color(&self, color: &mut Rgba<u8>) {
+        self.map_pixel(color.channels_mut())
     }
 }
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -48,7 +48,9 @@ pub use self::colorops:: {
 };
 
 mod affine;
-mod colorops;
+/// Public only because of Rust bug:
+/// https://github.com/rust-lang/rust/issues/18241
+pub mod colorops; 
 mod sample;
 
 /// Return a mutable view into an image

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,2 +1,3 @@
 //! Mathematical helper functions and types.
 pub mod utils;
+pub mod nq;

--- a/src/math/nq.rs
+++ b/src/math/nq.rs
@@ -1,0 +1,395 @@
+//! NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994.
+//! See "Kohonen neural networks for optimal colour quantization"
+//! in "Network: Computation in Neural Systems" Vol. 5 (1994) pp 351-367.
+//! for a discussion of the algorithm.
+//! See also  http://www.acm.org/~dekker/NEUQUANT.HTML
+
+/* NeuQuant Neural-Net Quantization Algorithm
+ * ------------------------------------------
+ *
+ * Copyright (c) 1994 Anthony Dekker
+ *
+ * NEUQUANT Neural-Net quantization algorithm by Anthony Dekker, 1994.
+ * See "Kohonen neural networks for optimal colour quantization"
+ * in "Network: Computation in Neural Systems" Vol. 5 (1994) pp 351-367.
+ * for a discussion of the algorithm.
+ * See also  http://www.acm.org/~dekker/NEUQUANT.HTML
+ *
+ * Any party obtaining a copy of these files from the author, directly or
+ * indirectly, is granted, free of charge, a full and unrestricted irrevocable,
+ * world-wide, paid up, royalty-free, nonexclusive right and license to deal
+ * in this software and documentation files (the "Software"), including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons who receive
+ * copies from any such party to do so, with the only requirement being
+ * that this copyright notice remain intact.
+ *
+ *
+ * Incorporated bugfixes and alpha channel handling from pngnq
+ * http://pngnq.sourceforge.net
+ *
+ */
+
+use std::num::Float;
+
+const CHANNELS: usize = 4;
+
+const RADIUS_DEC: i32 = 30; // factor of 1/30 each cycle
+
+const ALPHA_BIASSHIFT: i32 = 10;            // alpha starts at 1
+const INIT_ALPHA: i32 = 1<<ALPHA_BIASSHIFT; // biased by 10 bits
+
+const GAMMA: f64 = 1024.0;
+const BETA: f64 = 1.0/1024.0;
+const BETAGAMMA: f64 = BETA * GAMMA;
+
+// four primes near 500 - assume no image has a length so large
+// that it is divisible by all four primes
+const PRIMES: [usize; 4] = [499, 491, 478, 503];
+
+#[derive(Copy)]
+struct Neuron {
+    r: f64,
+    g: f64,
+    b: f64,
+    a: f64,
+}
+
+#[derive(Copy)]
+struct Color {
+    r: i32,
+    g: i32,
+    b: i32,
+    a: i32,
+}
+
+macro_rules! clamp(
+    ($x:expr) => (match $x {
+        x if x < 0 => 0,
+        x if x > 255 => 255,
+        x => x
+    })
+);
+
+macro_rules! abs(
+    ($x:expr) => (match $x {
+        x if x < 0.0 => -x,
+        x => x
+    })
+);
+
+/// Neural network color quantizer
+pub struct NeuQuant {
+    network: Vec<Neuron>,
+    colormap: Vec<Color>,
+    netindex: Vec<usize>, // for network lookup - really 256
+    bias: Vec<f64>, // bias and freq arrays for learning
+    freq: Vec<f64>,
+    samplefac: i32,
+    netsize: usize,
+}
+
+impl NeuQuant {
+    
+    /// Creates a new neuronal network and trains it with the supplied data
+    pub fn new(samplefac: i32, colors: usize, pixels: &[u8]) -> NeuQuant {
+        let netsize = colors;
+        let mut this = NeuQuant {
+            network: Vec::with_capacity(netsize),
+            colormap: Vec::with_capacity(netsize),
+            netindex: Vec::with_capacity(256),
+            bias: Vec::with_capacity(netsize),
+            freq: Vec::with_capacity(netsize),
+            samplefac: samplefac,
+            netsize: colors
+        };
+        this.init(pixels);
+        this
+    }
+    
+    /// Initializes the neuronal network and trains it with the supplied data
+    pub fn init(&mut self, pixels: &[u8]) {
+        self.network.clear();
+        self.colormap.clear();
+        self.netindex.clear();
+        self.bias.clear();
+        self.freq.clear();
+        let freq = 1.0/self.netsize as f64;
+        for i in 0..self.netsize {
+            let tmp = i as f64 * 256.0/self.netsize as f64;
+            // Sets alpha values at 0 for dark pixels.
+            let a = if i < 16 { i as f64 * 16.0 } else { 255.0 };
+            self.network.push(Neuron { r: tmp, g: tmp, b: tmp, a: a});
+            self.colormap.push(Color { r: 0, g: 0, b: 0, a: 255 });
+            self.freq.push(freq);
+            self.bias.push(0.0);
+        }
+        for _ in 0..256 {
+            self.netindex.push(0);
+        }
+        self.learn(pixels);
+        self.build_colormap();
+        self.inxbuild();
+    }
+
+    /// Maps the pixel in-place to the best-matching color in the color map
+    #[inline(always)]
+    pub fn map_pixel(&self, pixel: &mut [u8]) {
+        match pixel {
+            [r, g, b, a] => {
+                let i = self.inxsearch(b, g, r, a);
+                pixel[0] = self.colormap[i].r as u8;
+                pixel[1] = self.colormap[i].g as u8;
+                pixel[2] = self.colormap[i].b as u8;
+                pixel[3] = self.colormap[i].a as u8;
+            }
+            _ => panic!()
+        }
+    }
+
+    /// Finds the best-matching index in the color map for `pixel`
+    #[inline(always)]
+    pub fn index_of(&self, pixel: &[u8]) -> usize {
+        match pixel {
+            [r, g, b, a] => {
+                self.inxsearch(b, g, r, a)
+            }
+            _ => panic!()
+        }
+    }
+    
+    /*
+    /// Returns the color map in the format [r, g, b, r, g, ...]
+    pub fn colormap_rgb(&mut self, pixel: &mut [u8]) -> Vec<u8> {
+        self.colormap.iter().flat_map(|&c| [c.r as u8, c.g as u8, c.b as u8].iter().map(|&v| v)).collect()
+    }*/
+
+    /// Move neuron i towards biased (a,b,g,r) by factor alpha
+    fn altersingle(&mut self, alpha: f64, i: i32, b: f64, g: f64, r: f64, a: f64) {
+        // Move neuron i towards biased (b,g,r) by factor alpha
+        let n = &mut self.network[i as usize]; // alter hit neuron
+        n.b -= alpha*(n.b - b);
+        n.g -= alpha*(n.g - g);
+        n.r -= alpha*(n.r - r);
+        n.a -= alpha*(n.a - a);
+    }
+    
+    /// Move neuron adjacent neurons towards biased (a,b,g,r) by factor alpha
+    fn alterneigh(&mut self, alpha: f64, rad: i32, i: i32, b: f64, g: f64, r: f64, a: f64) {
+        
+        let mut lo = i-rad;   if lo<0 {lo=0};
+        let mut hi = i+rad;   if hi>self.netsize as i32 {hi=self.netsize as i32};
+        let mut j = i+1;
+        let mut k = i-1;
+        let mut q = 0;
+        while (j<hi) || (k>lo) {
+            let rad_sq = rad as f64 * rad as f64;
+            let alpha = (alpha * (rad_sq - q as f64 * q as f64)) / rad_sq;
+            q += 1;
+            if j<hi {
+                let p = &mut self.network[j as usize];
+                p.b -= alpha*(p.b - b);
+                p.g -= alpha*(p.g - g);
+                p.r -= alpha*(p.r - r);
+                p.a -= alpha*(p.a - a);
+                j += 1;
+            }
+            if k>lo {
+                let p = &mut self.network[k as usize];
+                p.b -= alpha*(p.b - b);
+                p.g -= alpha*(p.g - g);
+                p.r -= alpha*(p.r - r);
+                p.a -= alpha*(p.a - a);
+                k -= 1;
+            }
+        }
+    }
+    
+    /// Search for biased BGR values
+    /// finds closest neuron (min dist) and updates freq 
+    /// finds best neuron (min dist-bias) and returns position 
+    /// for frequently chosen neurons, freq[i] is high and bias[i] is negative 
+    /// bias[i] = gamma*((1/self.netsize)-freq[i]) 
+    fn contest (&mut self, b: f64, g: f64, r: f64, a: f64) -> i32 {
+        let mut bestd = Float::max_value();
+        let mut bestbiasd: f64 = bestd;
+        let mut bestpos = -1;
+        let mut bestbiaspos: i32 = bestpos;
+        
+        for i in 0..self.netsize {
+            let bestbiasd_biased = bestbiasd + self.bias[i];
+            let mut dist;
+            let n = &self.network[i];
+            dist  = abs!(n.b - b);
+            dist += abs!(n.r - r);
+            if dist < bestd || dist < bestbiasd_biased {
+                dist += abs!(n.g - g);
+                dist += abs!(n.a - a);
+                if dist < bestd {bestd=dist; bestpos=i as i32;}
+                let biasdist = dist - self.bias [i];
+                if biasdist < bestbiasd {bestbiasd=biasdist; bestbiaspos=i as i32;}
+            }
+            self.freq[i] -= BETA * self.freq[i];
+            self.bias[i] += BETAGAMMA * self.freq[i];
+        }
+        self.freq[bestpos as usize] += BETA;
+        self.bias[bestpos as usize] -= BETAGAMMA;
+        return bestbiaspos;
+    }
+    
+    /// Main learning loop
+    /// Note: the number of learning cycles is crucial and the parameters are not 
+    /// optimized for net sizes < 26 or > 256. 1064 colors seems to work fine
+    fn learn(&mut self, pixels: &[u8]) {
+        let initrad: i32 = self.netsize as i32/8;   // for 256 cols, radius starts at 32
+        let radiusbiasshift: i32 = 6;
+        let radiusbias: i32 = 1 << radiusbiasshift;
+        let init_bias_radius: i32 = initrad*radiusbias;
+        let mut bias_radius = init_bias_radius;
+        let alphadec = 30 + ((self.samplefac-1)/3);
+        let lengthcount = pixels.len() / CHANNELS;
+        let samplepixels = lengthcount / self.samplefac as usize;
+        // learning cycles
+        let n_cycles = match self.netsize >> 1 { n if n <= 100 => 100, n => n}; 
+        let delta = match samplepixels / n_cycles { 0 => 1, n => n };
+        let mut alpha = INIT_ALPHA;
+        
+        let mut rad = bias_radius >> radiusbiasshift;
+        if rad <= 1 {rad = 0};
+    
+        let mut pos = 0;
+        let step = *PRIMES.iter()
+            .find(|&&prime| lengthcount % prime != 0)
+            .unwrap_or(&PRIMES[3]);
+
+        let mut i = 0;
+        while i < samplepixels {
+
+            let (r, g, b, a) = {
+                let p = &pixels[CHANNELS * pos..][..CHANNELS];
+                (p[0] as f64, p[1] as f64, p[2] as f64, p[3] as f64)
+            };
+
+            let j =  self.contest (b, g, r, a);
+
+            let alpha_ = (1.0 * alpha as f64) / INIT_ALPHA as f64;
+            self.altersingle(alpha_, j, b, g, r, a);
+            if rad > 0 {self.alterneigh (alpha_, rad, j, b, g, r, a)};   // alter neighbours
+            
+            pos += step;
+            while pos >= lengthcount {pos -= lengthcount};
+            
+            i += 1;
+            if i%delta == 0 {   
+                alpha -= alpha / alphadec;
+                bias_radius -= bias_radius / RADIUS_DEC;
+                rad = bias_radius >> radiusbiasshift;
+                if rad <= 1 {rad = 0};
+            }
+        }
+    }
+
+    /// initializes the color map
+    fn build_colormap(&mut self) {
+        for i in 0us..self.netsize {
+            self.colormap[i].b = clamp!((0.5 + self.network[i].b) as i32);
+            self.colormap[i].g = clamp!((0.5 + self.network[i].g) as i32);
+            self.colormap[i].r = clamp!((0.5 + self.network[i].r) as i32);
+            self.colormap[i].a = clamp!((0.5 + self.network[i].a) as i32);
+        }
+    }
+
+    /// Insertion sort of network and building of netindex[0..255]
+    fn inxbuild(&mut self) {
+        let mut previouscol = 0;
+        let mut startpos = 0;
+
+        for i in 0..self.netsize {
+            let mut p = self.colormap[i];
+            let mut q;
+            let mut smallpos = i;
+            let mut smallval = p.g as usize;            // index on g
+            // find smallest in i..netsize-1
+            for j in (i + 1)..self.netsize {
+                q = self.colormap[j];
+                if (q.g as usize) < smallval {      // index on g
+                    smallpos = j;
+                    smallval = q.g as usize;    // index on g
+                }
+            }
+            q = self.colormap[smallpos];
+            // swap p (i) and q (smallpos) entries
+            if i != smallpos {
+                let mut j;
+                j = q;   q = p;   p = j;
+                self.colormap[i] = p;
+                self.colormap[smallpos] = q;
+            }
+            // smallval entry is now in position i
+            if smallval != previouscol {
+                self.netindex[previouscol] = (startpos + i)>>1;
+                for j in (previouscol + 1)..smallval { 
+                    self.netindex[j] = i
+                }
+                previouscol = smallval;
+                startpos = i;
+            }
+        }
+        let max_netpos = self.netsize - 1;
+        self.netindex[previouscol] = (startpos + max_netpos)>>1;
+        for j in (previouscol + 1)..256 { self.netindex[j] = max_netpos }; // really 256
+    }
+
+    /// Search for best matching color
+    fn inxsearch(&self, b: u8, g: u8, r: u8, a: u8) -> usize {
+        let mut bestd = 1 << 30; // ~ 1_000_000
+        let mut best = 0;
+        // start at netindex[g] and work outwards
+        let mut i = self.netindex[g as usize];
+        let mut j = if i > 0 { i - 1 } else { 0 };
+
+        while (i < self.netsize) || (j >  0) {
+            if i < self.netsize {
+                let p = self.colormap[i];
+                let mut e = p.g - g as i32;
+                let mut dist = e*e; // inx key
+                if dist >= bestd { break }
+                else {
+                    e = p.b - b as i32;
+                    dist += e*e;
+                    if dist < bestd {
+                        e = p.r - r as i32;
+                        dist += e*e;
+                        if dist < bestd {
+                            e = p.a - a as i32;
+                            dist += e*e;
+                            if dist < bestd { bestd = dist; best = i;}
+                        }
+                    }
+                    i += 1;
+                }
+            }
+            if j > 0 {
+                let p = self.colormap[j];
+                let mut e = p.g - g as i32;
+                let mut dist = e*e; // inx key
+                if dist >= bestd { break }
+                else {
+                    e = p.b - b as i32;
+                    dist += e*e;
+                    if dist < bestd {
+                        e = p.r - r as i32;
+                        dist += e*e;
+                        if dist < bestd {
+                            e = p.a - a as i32;
+                            dist += e*e;
+                            if dist < bestd { bestd = dist; best = j; }
+                        }
+                    }
+                    j -= 1;
+                }
+            }
+        }
+        best
+    }
+}


### PR DESCRIPTION
Ported the NeuQuant color quantizer to Rust. As expected, better results than gimp. It is the default for gif now.

Full support for alpha channel. Just our png encoder doesn’t write indexed colors yet so we don’t save any space.

Us:
![lena_nq](https://cloud.githubusercontent.com/assets/949560/6173342/73a26ed2-b2e7-11e4-8088-fe5d1c00c722.gif)
GIMP:
![lena_gimp](https://cloud.githubusercontent.com/assets/949560/6173347/7f6fbd28-b2e7-11e4-84da-e6868aeda3fc.gif)
