### PR TITLE
Fixed panics from arithmetic overflow

### DIFF
--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -8,6 +8,7 @@ use std::slice;
 use std::old_io::IoResult;
 use std::old_io::MemReader;
 use std::num::FromPrimitive;
+use std::num::wrapping::Wrapping;
 
 use image::{
     DecodingResult,
@@ -509,7 +510,7 @@ fn expand_palette(buf: &mut[u8], palette: &[(u8, u8, u8)],
                   entries: usize, bit_depth: u8) {
     let bpp = 8 / bit_depth as usize;
     assert_eq!(buf.len(), 3 * (entries * bpp - buf.len() % bpp));
-    let mask = (1u8 << bit_depth as usize) - 1;
+    let mask = (Wrapping(1u8 << bit_depth as usize) - Wrapping(1)).0;
     // Unsafe copy create two views into the vector
     // This is unproblematic since it is only locally to this function and a &[u8]
     let data = unsafe {

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -1,4 +1,5 @@
 use std::num::SignedInt;
+use std::num::wrapping::Wrapping as w;
 
 #[derive(FromPrimitive, Debug)]
 pub enum FilterType {
@@ -36,30 +37,30 @@ pub fn unfilter(filter: FilterType, bpp: usize, previous: &[u8], current: &mut [
         FilterType::NoFilter => (),
         FilterType::Sub => {
             for i in (bpp..len) {
-                current[i] += current[i - bpp];
+                current[i] = (w(current[i]) + w(current[i - bpp])).0;
             }
         }
         FilterType::Up => {
             for i in (0..len) {
-                current[i] += previous[i];
+                current[i] = (w(current[i]) + w(previous[i])).0;
             }
         }
         FilterType::Avg => {
             for i in (0..bpp) {
-                current[i] += previous[i] / 2;
+                current[i] = (w(current[i]) + w(previous[i] / 2)).0;
             }
 
             for i in (bpp..len) {
-                current[i] += ((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8;
+                current[i] = (w(current[i]) + w(((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8)).0;
             }
         }
         FilterType::Paeth => {
             for i in (0..bpp) {
-                current[i] += filter_paeth(0, previous[i], 0);
+                current[i] = (w(current[i]) + w(filter_paeth(0, previous[i], 0))).0;
             }
 
             for i in (bpp..len) {
-                current[i] += filter_paeth(current[i - bpp], previous[i], previous[i - bpp]);
+                current[i] = (w(current[i]) + w(filter_paeth(current[i - bpp], previous[i], previous[i - bpp]))).0;
             }
         }
     }
@@ -72,30 +73,30 @@ pub fn filter(method: FilterType, bpp: usize, previous: &[u8], current: &mut [u8
         FilterType::NoFilter => (),
         FilterType::Sub      => {
             for i in (bpp..len).rev() {
-                current[i] = current[i] - current[i - bpp];
+                current[i] = (w(current[i]) - w(current[i - bpp])).0;
             }
         }
         FilterType::Up       => {
             for i in (0..len) {
-                current[i] = current[i] - previous[i];
+                current[i] = (w(current[i]) - w(previous[i])).0;
             }
         }
         FilterType::Avg  => {
             for i in (bpp..len).rev() {
-                current[i] = current[i] - ((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8;
+                current[i] = (w(current[i]) - w(((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8)).0;
             }
 
             for i in (0..bpp) {
-                current[i] = current[i] - previous[i] / 2;
+                current[i] = (w(current[i]) - w(previous[i] / 2)).0;
             }
         }
         FilterType::Paeth    => {
             for i in (bpp..len).rev() {
-                current[i] = current[i] - filter_paeth(current[i - bpp], previous[i], previous[i - bpp]);
+                current[i] = (w(current[i]) - w(filter_paeth(current[i - bpp], previous[i], previous[i - bpp]))).0;
             }
 
             for i in (0..bpp) {
-                current[i] = current[i] - filter_paeth(0, previous[i], 0);
+                current[i] = (w(current[i]) - w(filter_paeth(0, previous[i], 0))).0;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/PistonDevelopers/image/issues/314. Overflow triggers panics in `rustc 1.0.0-nightly (fed12499e 2015-03-03) (built 2015-03-04)`, need to use `std::num::wrapping::Wrapping` when overflow is expected/intentional. See https://github.com/rust-lang/rand/commit/929ea771f2bd505bf4ce872bd43e3afc098241ae for a related fix.

Not sure how complete test coverage is in this lib, there could be more places this might blow up, but it's working for me now.