### PR TITLE
Fix integer overflow

### DIFF
--- a/src/png/encoder.rs
+++ b/src/png/encoder.rs
@@ -164,11 +164,13 @@ fn build_idat(image: &[u8], bpp: usize, width: u32, height: u32) -> Vec<u8> {
 
         outrow[0]  = filter;
         let out    = &mut outrow[1..];
-        let stride = (filter as usize - 1) * rowlen;
 
         match filter {
             0 => slice::bytes::copy_memory(out, row),
-            _ => slice::bytes::copy_memory(out, &c[stride..stride + rowlen]),
+            _ => {
+                let stride = (filter as usize - 1) * rowlen;
+                slice::bytes::copy_memory(out, &c[stride..stride + rowlen])
+            }
         }
 
         slice::bytes::copy_memory(&mut p, row);


### PR DESCRIPTION
Don't try to create the stride binding when you would be subtracting 1 from an unsigned 0 value.

Trying to write a PNG image panics with integer overflow here otherwise.