### PR TITLE
Use cargo features to conditionally compile codecs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,25 @@ os:
 env:
     global:
         - secure: M2MCRtyP5P/Xf2TSqrbz8cs41TQY04mK/5Fi6qgr77OKLNZlDclKiFY8BmQ6f1JhVccoE5gMIFpfPoVUu8wZ0Pe7/X4IyO4vxWawVQfE6f0NYErD9yqiE1KEi/RGKPOQfL5HFUK7ifnXvLwsAMh1ix9XMgaBZfZLQ8KhkxNRXwI=
+    matrix:
+      - FEATURES=''
+      - FEATURES='gif'
+      - FEATURES='jpeg'
+      - FEATURES='png'
+      - FEATURES='ppm'
+      - FEATURES='tga'
+      - FEATURES='tiff'
+      - FEATURES='webp'
 script:
-    - cargo build -v
-    - cargo test -v
-    - cargo doc -v
+    - if [ -z "$FEATURES" ]; then
+        cargo build -v;
+        cargo test -v;
+        cargo doc -v;
+      else
+        cargo build -v --no-default-features --features "$FEATURES";
+        cargo test -v --no-default-features --features "$FEATURES";
+        cargo doc -v;
+      fi
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,14 @@ version = "0.1.15"
 
 [dev-dependencies.glob]
 version = "0.2.3"
+
+[features]
+default = ["gif", "jpeg", "png", "ppm", "tga", "tiff", "webp"]
+
+gif = []
+jpeg = []
+png = []
+ppm = []
+tga = []
+tiff = []
+webp = []

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -475,6 +475,7 @@ mod tests {
     use super::{resize, FilterType};
 
     #[bench]
+    #[cfg(feature = "png")]
     fn bench_resize(b: &mut test::Bencher) {
         let img = ::open(&Path::new("./examples/fractal.png")).unwrap();
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,12 +109,19 @@ pub mod math;
 pub mod imageops;
 
 // Image Codecs
+#[cfg(feature = "webp")]
 pub mod webp;
+#[cfg(feature = "ppm")]
 pub mod ppm;
+#[cfg(feature = "png")]
 pub mod png;
+#[cfg(feature = "jpeg")]
 pub mod jpeg;
+#[cfg(feature = "gif")]
 pub mod gif;
+#[cfg(feature = "tiff")]
 pub mod tiff;
+#[cfg(feature = "tga")]
 pub mod tga;
 
 

--- a/tests/tga.rs
+++ b/tests/tga.rs
@@ -1,4 +1,5 @@
 #![feature(old_io, old_path)]
+#![cfg(feature = "tga")]
 
 extern crate image;
 


### PR DESCRIPTION
The default continues to have all codecs activated, but a user can
opt-in to only supporting specific ones, via features, e.g. depending on
`image`, while only supporting JPEG and GIF:

    [dependencies.image]
    version = "0.2"
    default-features = false
    features = ["jpeg", "gif"]

On my computer `cargo build` takes ~95s, while `cargo build --features
jpeg --no-default-features` (only JPEG) takes ~28s.

This patch also updates the travis file to also compile the library with
each feature, to ensure they continue to compile. These codec features
are all independent, so testing each one individually is sufficient.

Closes #311.