### PR TITLE
Rustup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -62,9 +62,9 @@ impl<R: Reader> GIFDecoder<R> {
             try!(self.r.read_at_least(3, &mut signature));
             try!(self.r.read_at_least(3, &mut version));
 
-            if signature != b"GIF" {
+            if signature != b"GIF"[..] {
                 Err(ImageError::FormatError("GIF signature not found.".to_string()))
-            } else if version != b"87a" && version != b"89a" {
+            } else if version != b"87a"[..] && version != b"89a"[..] {
                 Err(ImageError::UnsupportedError(
                     format!("GIF version {:?} is not supported.", version)
                 ))


### PR DESCRIPTION
Items like `b"GIF"` are now of type `[u8; 3]` instead of `[u8]` before.
This lead to the comparison not working.