### PR TITLE
Switch to new I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ exclude = [
 name = "image"
 path = "./src/lib.rs"
 
+[dependencies.byteorder]
+version = "0.3.1"
+
 [dependencies.num]
 version = "0.1.15"
 

--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -1,10 +1,9 @@
 //!An example of generating julia fractals.
-#![feature(old_path, old_io)]
-
 extern crate num;
 extern crate image;
 
-use std::old_io::File;
+use std::fs::File;
+use std::path::Path;
 
 use num::complex::Complex;
 

--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -1,10 +1,9 @@
 //! An example of opening an image.
-#![feature(old_path, old_io)]
-
 extern crate image;
 
 use std::env;
-use std::old_io::File;
+use std::fs::File;
+use std::path::PathBuf;
 
 use image::GenericImage;
 
@@ -17,7 +16,7 @@ fn main() {
 
     // Use the open function to load an image from a PAth.
     // ```open``` returns a dynamic image.
-    let im = image::open(&Path::new(file.clone())).unwrap();
+    let im = image::open(&PathBuf::new(file.clone())).unwrap();
 
     // The dimensions method returns the images width and height
     println!("dimensions {:?}", im.dimensions());
@@ -25,7 +24,7 @@ fn main() {
     // The color method returns the image's ColorType
     println!("{:?}", im.color());
 
-    let ref mut fout = File::create(&Path::new(format!("{}.png", file))).unwrap();
+    let ref mut fout = File::create(&PathBuf::new(format!("{}.png", file))).unwrap();
 
     // Write the contents of this image to the Writer in PNG format.
     let _ = im.save(fout, image::PNG).unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,8 +4,8 @@ use std::ops::{ Deref, DerefMut, Index, IndexMut };
 use std::marker::PhantomData;
 use std::num::Int;
 use std::iter::repeat;
-use std::old_io::IoResult;
-use std::old_path::*;
+use std::path::AsPath;
+use std::io;
 
 use traits::{ Zero, Primitive };
 use color::{ Rgb, Rgba, Luma, LumaA, FromColor, ColorType };
@@ -353,7 +353,7 @@ where P: Pixel<Subpixel=u8> + 'static,
     ///
     /// The image format is derived from the file extension.
     /// Currently only jpeg and png files are supported.
-    pub fn save(&self, path: &Path) -> IoResult<()> {
+    pub fn save<Q>(&self, path: &Q) -> io::Result<()> where Q: AsPath {
         // This is valid as the subpixel is u8.
         save_buffer(path,
                     self.as_slice(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -353,7 +353,7 @@ where P: Pixel<Subpixel=u8> + 'static,
     ///
     /// The image format is derived from the file extension.
     /// Currently only jpeg and png files are supported.
-    pub fn save<Q>(&self, path: &Q) -> io::Result<()> where Q: AsPath {
+    pub fn save<Q>(&self, path: Q) -> io::Result<()> where Q: AsPath {
         // This is valid as the subpixel is u8.
         save_buffer(path,
                     self.as_slice(),

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -510,6 +510,8 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
 /// Open the image located at the path specified.
 /// The image's format is determined from the path's file extension.
 pub fn open<P>(path: P) -> ImageResult<DynamicImage> where P: AsPath {
+    let path = path.as_path();
+
     let fin = match File::open(path) {
         Ok(f)  => f,
         Err(err) => return Err(image::ImageError::IoError(err))
@@ -544,8 +546,9 @@ pub fn open<P>(path: P) -> ImageResult<DynamicImage> where P: AsPath {
 /// This will lead to corrupted files if the buffer contains malformed data. Currently only
 /// jpeg and png files are supported.
 pub fn save_buffer<P>(path: P, buf: &[u8], width: u32, height: u32, color: color::ColorType) -> io::Result<()> where P: AsPath {
+    let path = path.as_path();
     let ref mut fout = try!(File::create(path));
-    let ext = path.as_path().extension().and_then(|s| s.to_str())
+    let ext = path.extension().and_then(|s| s.to_str())
                   .map_or("".to_string(), |s| s.to_string().into_ascii_lowercase());
 
     match &*ext {

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -5,7 +5,8 @@
 // A very good resource for the file format is
 // http://giflib.sourceforge.net/whatsinagif/bits_and_bytes.html
 
-use std::io::Read;
+use std::io::{self, Read};
+use byteorder::{ReadBytesExt, LittleEndian};
 use std::num::FromPrimitive;
 
 use num::rational::Ratio;
@@ -58,9 +59,14 @@ impl<R: Read> GIFDecoder<R> {
     fn read_header(&mut self) -> ImageResult<()> {
         if self.state == State::Start {
             let mut signature = [0; 3];
+            if try!(self.r.read(&mut signature)) != 3 {
+                return Err(ImageError::ImageEnd);
+            }
+
             let mut version = [0; 3];
-            try!(self.r.read_at_least(3, &mut signature));
-            try!(self.r.read_at_least(3, &mut version));
+            if try!(self.r.read(&mut version)) != 3 {
+                return Err(ImageError::ImageEnd);
+            }
 
             if signature != b"GIF"[..] {
                 Err(ImageError::FormatError("GIF signature not found.".to_string()))
@@ -78,8 +84,8 @@ impl<R: Read> GIFDecoder<R> {
     fn read_logical_screen_descriptor(&mut self) -> ImageResult<()> {
         try!(self.read_header());
         if self.state == State::HaveHeader {
-            self.width  = try!(self.r.read_le_u16());
-            self.height = try!(self.r.read_le_u16());
+            self.width  = try!(self.r.read_u16::<LittleEndian>());
+            self.height = try!(self.r.read_u16::<LittleEndian>());
 
             let fields = try!(self.r.read_u8());
 
@@ -99,7 +105,8 @@ impl<R: Read> GIFDecoder<R> {
 
             let _aspect_ratio = try!(self.r.read_u8());
 
-            let buf = try!(self.r.read_exact(3 * entries));
+            let mut buf = Vec::with_capacity(3 * entries);
+            try!(self.r.by_ref().take(3 * entries as u64).read_to_end(&mut buf));
 
             for rgb in buf.chunks(3) {
                 self.global_table.push((rgb[0], rgb[1], rgb[2]));
@@ -130,7 +137,7 @@ impl<R: Read> GIFDecoder<R> {
             ))
         }
         let fields = try!(self.r.read_u8());
-        self.delay = try!(self.r.read_le_u16());
+        self.delay = try!(self.r.read_u16::<LittleEndian>());
         let trans  = try!(self.r.read_u8());
 
         if fields & 1 != 0 {
@@ -162,7 +169,7 @@ impl<R: Read> GIFDecoder<R> {
         let mut size = try!(self.r.read_u8()) as usize;
         let mut data = Vec::with_capacity(size);
         while size != 0 {
-            data.push_all(&try!(self.r.read_exact(size)));
+            try!(self.r.by_ref().take(size as u64).read_to_end(&mut data));
             size = try!(self.r.read_u8()) as usize;
         }
         Ok(data)
@@ -170,10 +177,10 @@ impl<R: Read> GIFDecoder<R> {
 
     #[allow(unused_variables)]
     fn read_frame(&mut self) -> ImageResult<Frame> {
-        let image_left   = try!(self.r.read_le_u16());
-        let image_top    = try!(self.r.read_le_u16());
-        let image_width  = try!(self.r.read_le_u16());
-        let image_height = try!(self.r.read_le_u16());
+        let image_left   = try!(self.r.read_u16::<LittleEndian>());
+        let image_top    = try!(self.r.read_u16::<LittleEndian>());
+        let image_width  = try!(self.r.read_u16::<LittleEndian>());
+        let image_height = try!(self.r.read_u16::<LittleEndian>());
 
         let fields = try!(self.r.read_u8());
 
@@ -190,7 +197,8 @@ impl<R: Read> GIFDecoder<R> {
         let local_table = if local_table {
             let entries = 1 << (table_size + 1) as usize;
             let mut table = Vec::with_capacity(entries * 3);
-            let buf = try!(self.r.read_exact(3 * entries));
+            let mut buf = Vec::with_capacity(3 * entries);
+            try!(self.r.by_ref().take(3 * entries as u64).read_to_end(&mut buf));
 
             for rgb in buf.chunks(3) {
                 table.push((rgb[0], rgb[1], rgb[2]));
@@ -208,7 +216,7 @@ impl<R: Read> GIFDecoder<R> {
             * image_height as usize
         );
         try!(lzw::decode(
-            LsbReader::new(&data),
+            LsbReader::new(io::Cursor::new(data)),
             &mut indices,
             code_size
         ));

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -5,8 +5,7 @@
 // A very good resource for the file format is
 // http://giflib.sourceforge.net/whatsinagif/bits_and_bytes.html
 
-use std::old_io;
-use std::old_io::*;
+use std::io::Read;
 use std::num::FromPrimitive;
 
 use num::rational::Ratio;
@@ -28,7 +27,7 @@ enum State {
 }
 
 /// A gif decoder
-pub struct GIFDecoder<R: Reader> {
+pub struct GIFDecoder<R: Read> {
     r: R,
     state: State,
 
@@ -40,7 +39,7 @@ pub struct GIFDecoder<R: Reader> {
     local_transparent_index: Option<u8>,
 }
 
-impl<R: Reader> GIFDecoder<R> {
+impl<R: Read> GIFDecoder<R> {
     /// Creates a new GIF decoder
     pub fn new(r: R) -> GIFDecoder<R> {
         GIFDecoder {
@@ -209,7 +208,7 @@ impl<R: Reader> GIFDecoder<R> {
             * image_height as usize
         );
         try!(lzw::decode(
-            LsbReader::new(old_io::MemReader::new(data)),
+            LsbReader::new(&data),
             &mut indices,
             code_size
         ));
@@ -257,7 +256,7 @@ impl<R: Reader> GIFDecoder<R> {
     }
 }
 
-impl<R: Reader> ImageDecoder for GIFDecoder<R> {
+impl<R: Read> ImageDecoder for GIFDecoder<R> {
     fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
         let _ = try!(self.read_logical_screen_descriptor());
         Ok((self.width as u32, self.height as u32))

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::slice;
 use std::iter::repeat;
 
+use byteorder;
+
 use color;
 use color::ColorType;
 use buffer::{ImageBuffer, Pixel};
@@ -59,6 +61,15 @@ impl fmt::Display for ImageError {
 impl FromError<io::Error> for ImageError {
     fn from_error(err: io::Error) -> ImageError {
         ImageError::IoError(err)
+    }
+}
+
+impl FromError<byteorder::Error> for ImageError {
+    fn from_error(err: byteorder::Error) -> ImageError {
+        match err {
+            byteorder::Error::UnexpectedEOF => ImageError::ImageEnd,
+            byteorder::Error::Io(err) => ImageError::IoError(err),
+        }
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,7 @@
 use std::error::FromError;
 use std::fmt;
 use std::mem;
-use std::old_io;
+use std::io;
 use std::slice;
 use std::iter::repeat;
 
@@ -32,7 +32,7 @@ pub enum ImageError {
     NotEnoughData,
 
     /// An I/O Error occurred while decoding the image
-    IoError(old_io::IoError),
+    IoError(io::Error),
 
     /// The end of the image has been reached
     ImageEnd
@@ -56,8 +56,8 @@ impl fmt::Display for ImageError {
     }
 }
 
-impl FromError<old_io::IoError> for ImageError {
-    fn from_error(err: old_io::IoError) -> ImageError {
+impl FromError<io::Error> for ImageError {
+    fn from_error(err: io::Error) -> ImageError {
         ImageError::IoError(err)
     }
 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -473,6 +473,7 @@ mod tests {
     use test;
     use buffer::{ImageBuffer, RgbImage};
     use super::{resize, FilterType};
+    use std::path::Path;
 
     #[bench]
     #[cfg(feature = "png")]

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,12 +1,13 @@
 use std::cmp;
 use std::slice;
+use std::io;
+use std::io::Read;
 use std::iter::range_step;
 use std::default::Default;
 use std::collections::vec_map::VecMap;
 use std::num::{ Float };
 use std::iter::repeat;
 use std::num::wrapping::WrappingOps;
-use std::old_io::*;
 
 use color;
 use super::transform;
@@ -133,7 +134,7 @@ pub struct JPEGDecoder<R> {
     state: JPEGState,
 }
 
-impl<R: Reader>JPEGDecoder<R> {
+impl<R: Read>JPEGDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> JPEGDecoder<R> {
         let h: HuffTable  = Default::default();
@@ -541,7 +542,7 @@ impl<R: Reader>JPEGDecoder<R> {
     }
 }
 
-impl<R: Reader> ImageDecoder for JPEGDecoder<R> {
+impl<R: Read> ImageDecoder for JPEGDecoder<R> {
     fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
         if self.state == JPEGState::Start {
             let _ = try!(self.read_metadata());

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -1,5 +1,4 @@
-use std::old_io;
-use std::old_io::*;
+use std::io::{self, Write};
 
 use std::iter::range_step;
 use std::num::{ Float, SignedInt };
@@ -140,7 +139,7 @@ pub struct JPEGEncoder<'a, W: 'a> {
     chroma_actable: Vec<(u8, u16)>,
 }
 
-impl<'a, W: Writer> JPEGEncoder<'a, W> {
+impl<'a, W: Write> JPEGEncoder<'a, W> {
     /// Create a new encoder that writes its output to ```w```
     pub fn new(w: &mut W) -> JPEGEncoder<W> {
         let ld = build_huff_lut(&STD_LUMA_DC_CODE_LENGTHS, &STD_LUMA_DC_VALUES);
@@ -183,7 +182,7 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
                   image: &[u8],
                   width: u32,
                   height: u32,
-                  c: color::ColorType) -> IoResult<()> {
+                  c: color::ColorType) -> io::Result<()> {
 
         let n = color::num_components(c);
         let num_components = if n == 1 || n == 2 {1}
@@ -242,21 +241,21 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
             color::ColorType::RGBA(8)  => try!(self.encode_rgb(image, width as usize, height as usize, 4)),
             color::ColorType::Gray(8)  => try!(self.encode_gray(image, width as usize, height as usize, 1)),
             color::ColorType::GrayA(8) => try!(self.encode_gray(image, width as usize, height as usize, 2)),
-            _  => return Err(old_io::IoError {
-                kind: old_io::InvalidInput,
-                desc: "Unsupported color type. Use 8 bit per channel RGB(A) or Gray(A) instead.",
-                detail: Some(format!(
+            _  => return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unsupported color type. Use 8 bit per channel RGB(A) or Gray(A) instead.",
+                Some(format!(
                     "Color type {:?} is not suppored by this JPEG encoder.",
                     c
                 ))
-            })
+            ))
         };
 
         let _ = try!(self.pad_byte());
         self.write_segment(EOI, None)
     }
 
-    fn write_segment(&mut self, marker: u8, data: Option<Vec<u8>>) -> IoResult<()> {
+    fn write_segment(&mut self, marker: u8, data: Option<Vec<u8>>) -> io::Result<()> {
         let _ = try!(self.w.write_u8(0xFF));
         let _ = try!(self.w.write_u8(marker));
 
@@ -269,7 +268,7 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
         Ok(())
     }
 
-    fn write_bits(&mut self, bits: u16, size: u8) -> IoResult<()> {
+    fn write_bits(&mut self, bits: u16, size: u8) -> io::Result<()> {
         self.accumulator |= (bits as u32) << (32 - (self.nbits + size)) as usize;
         self.nbits += size;
 
@@ -288,11 +287,11 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
         Ok(())
     }
 
-    fn pad_byte(&mut self) -> IoResult<()> {
+    fn pad_byte(&mut self) -> io::Result<()> {
         self.write_bits(0x7F, 7)
     }
 
-    fn huffman_encode(&mut self, val: u8, table: &[(u8, u16)]) -> IoResult<()> {
+    fn huffman_encode(&mut self, val: u8, table: &[(u8, u16)]) -> io::Result<()> {
         let (size, code) = table[val as usize];
 
         if size > 16 {
@@ -307,7 +306,7 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
         block: &[i32],
         prevdc: i32,
         dctable: &[(u8, u16)],
-        actable: &[(u8, u16)]) -> IoResult<i32> {
+        actable: &[(u8, u16)]) -> io::Result<i32> {
 
         // Differential DC encoding
         let dcval = block[0];
@@ -355,7 +354,7 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
         Ok(dcval)
     }
 
-    fn encode_gray(&mut self, image: &[u8], width: usize, height: usize, bpp: usize) -> IoResult<()> {
+    fn encode_gray(&mut self, image: &[u8], width: usize, height: usize, bpp: usize) -> io::Result<()> {
         let mut yblock     = [0u8; 64];
         let mut y_dcprev   = 0;
         let mut dct_yblock = [0i32; 64];
@@ -384,7 +383,7 @@ impl<'a, W: Writer> JPEGEncoder<'a, W> {
         Ok(())
     }
 
-    fn encode_rgb(&mut self, image: &[u8], width: usize, height: usize, bpp: usize) -> IoResult<()> {
+    fn encode_rgb(&mut self, image: &[u8], width: usize, height: usize, bpp: usize) -> io::Result<()> {
         let mut y_dcprev = 0;
         let mut cb_dcprev = 0;
         let mut cr_dcprev = 0;

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -1,5 +1,6 @@
 use std::iter::repeat;
 use std::io::Read;
+use byteorder::ReadBytesExt;
 use std::num::wrapping::WrappingOps;
 
 use image;

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -1,5 +1,5 @@
 use std::iter::repeat;
-use std::old_io::*;
+use std::io::Read;
 use std::num::wrapping::WrappingOps;
 
 use image;
@@ -31,7 +31,7 @@ impl HuffDecoder {
         }
     }
 
-    fn guarantee<R: Reader>(&mut self, r: &mut R, n: u8) -> ImageResult<()> {
+    fn guarantee<R: Read>(&mut self, r: &mut R, n: u8) -> ImageResult<()> {
         while self.num_bits < n && !self.end {
             let byte = try!(r.read_u8());
 
@@ -50,7 +50,7 @@ impl HuffDecoder {
         Ok(())
     }
 
-    pub fn read_bit<R: Reader>(&mut self, r: &mut R) -> ImageResult<u8> {
+    pub fn read_bit<R: Read>(&mut self, r: &mut R) -> ImageResult<u8> {
         let _   = try!(self.guarantee(r, 1));
         let bit = (self.bits & (1 << 31)) >> 31;
         self.consume(1);
@@ -60,7 +60,7 @@ impl HuffDecoder {
 
     // Section F.2.2.4
     // Figure F.17
-    pub fn receive<R: Reader>(&mut self, r: &mut R, ssss: u8) -> ImageResult<i32> {
+    pub fn receive<R: Read>(&mut self, r: &mut R, ssss: u8) -> ImageResult<i32> {
         let _ = try!(self.guarantee(r, ssss));
         let bits = (self.bits & (0xFFFFFFFFu32 << (32 - ssss as usize))) >> (32 - ssss) as usize;
         self.consume(ssss);
@@ -73,7 +73,7 @@ impl HuffDecoder {
         self.num_bits -= n;
     }
 
-    pub fn decode_symbol<R: Reader>(&mut self, r: &mut R, table: &HuffTable) -> ImageResult<u8> {
+    pub fn decode_symbol<R: Read>(&mut self, r: &mut R, table: &HuffTable) -> ImageResult<u8> {
         let _ = try!(self.guarantee(r, 8));
 
         let index = (self.bits & 0xFF000000) >> (32 - 8);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(rustc_private)]
 #![cfg_attr(test, feature(test))]
 
+extern crate byteorder;
 extern crate flate;
 extern crate num;
 #[cfg(test)] extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,10 @@
 #![warn(unused_features)] // reduce errors due to using test&rand features
 #![deny(missing_copy_implementations)]
 #![feature(core)]
-#![feature(old_io)]
-#![feature(old_path)]
 #![feature(collections)]
 #![feature(std_misc)]
 #![feature(rustc_private)]
-#![cfg_attr(test, feature(test, path))]
+#![cfg_attr(test, feature(test))]
 
 extern crate flate;
 extern crate num;

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -377,7 +377,7 @@ impl<R: Read> PNGDecoder<R> {
     }
 
     fn extract_scanline(&mut self, buf: &mut [u8], rlength: u32) -> ImageResult<u32> {
-        let filter_type = match FromPrimitive::from_u8(try!(try!(self.z.bytes().next().ok_or(ImageError::ImageEnd)))) {
+        let filter_type = match FromPrimitive::from_u8(try!(try!(self.z.by_ref().bytes().next().ok_or(ImageError::ImageEnd)))) {
             Some(v) => v,
             _ => return Err(ImageError::FormatError("Unknown filter type.".to_string()))
         };

--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -8,8 +8,7 @@
 use std::cmp;
 use std::iter::repeat;
 use std::num::wrapping::Wrapping as w;
-use std::old_io::*;
-use std::old_io;
+use std::io::{self, Read};
 
 static LITERALLENGTHCODES: u16 = 286;
 static DISTANCECODES: u16 = 30;
@@ -77,7 +76,7 @@ pub struct Inflater<R> {
     dtable: Vec<TableElement>,
 }
 
-impl<R: Reader> Inflater<R> {
+impl<R: Read> Inflater<R> {
     /// Create a new decoder that decodes from a Reader
     pub fn new(r: R) -> Inflater<R> {
         Inflater {
@@ -106,7 +105,7 @@ impl<R: Reader> Inflater<R> {
         &mut self.h.r
     }
 
-    fn read_block_type(&mut self) -> IoResult<()> {
+    fn read_block_type(&mut self) -> io::Result<()> {
         let is_final = try!(self.h.receive(1));
         self.finished = is_final == 1;
 
@@ -130,7 +129,7 @@ impl<R: Reader> Inflater<R> {
         Ok(())
     }
 
-    fn read_dynamic_tables(&mut self) -> IoResult<()> {
+    fn read_dynamic_tables(&mut self) -> io::Result<()> {
         let totalcodes = LITERALLENGTHCODES + DISTANCECODES;
 
         let hlit  = try!(self.h.receive(5)) + 257;
@@ -196,7 +195,7 @@ impl<R: Reader> Inflater<R> {
         self.dtable = table_from_lengths(&lengths);
     }
 
-    fn read_stored_block_length(&mut self) -> IoResult<()> {
+    fn read_stored_block_length(&mut self) -> io::Result<()> {
         self.h.byte_align();
 
         let len   = try!(self.h.receive(16));
@@ -207,7 +206,7 @@ impl<R: Reader> Inflater<R> {
         Ok(())
     }
 
-    fn read_stored_block(&mut self) -> IoResult<()> {
+    fn read_stored_block(&mut self) -> io::Result<()> {
         while self.block_length > 0 {
             let a = try!(self.h.receive(8));
 
@@ -219,7 +218,7 @@ impl<R: Reader> Inflater<R> {
         Ok(())
     }
 
-    fn read_compressed_block(&mut self) -> IoResult<()> {
+    fn read_compressed_block(&mut self) -> io::Result<()> {
         loop {
             let s = try!(self.h.decode_symbol(&self.lltable));
 
@@ -258,11 +257,11 @@ impl<R: Reader> Inflater<R> {
     }
 }
 
-impl<R: Reader> Reader for Inflater<R> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+impl<R: Read> Read for Inflater<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.pos as usize == self.buf.len() {
             if self.finished {
-                return Err(old_io::standard_error(old_io::EndOfFile))
+                return Ok(0);
             }
 
             let _ = try!(self.read_block_type());
@@ -362,12 +361,12 @@ struct HuffReader<R> {
     num_bits: u8,
 }
 
-impl<R: Reader> HuffReader<R> {
+impl<R: Read> HuffReader<R> {
     pub fn new(r: R) -> HuffReader<R> {
         HuffReader {r: r, bits: 0, num_bits: 0}
     }
 
-    pub fn guarantee(&mut self, n: u8) -> IoResult<()> {
+    pub fn guarantee(&mut self, n: u8) -> io::Result<()> {
         while self.num_bits < n {
             let byte = try!(self.r.read_u8());
 
@@ -390,7 +389,7 @@ impl<R: Reader> HuffReader<R> {
         self.num_bits -= n;
     }
 
-    pub fn receive(&mut self, n: u8) -> IoResult<u16> {
+    pub fn receive(&mut self, n: u8) -> io::Result<u16> {
         let _ = try!(self.guarantee(n));
 
         let val = self.bits & ((1 << n as usize) - 1);
@@ -399,7 +398,7 @@ impl<R: Reader> HuffReader<R> {
         Ok(val as u16)
     }
 
-    pub fn decode_symbol(&mut self, table: &[TableElement]) -> IoResult<u16> {
+    pub fn decode_symbol(&mut self, table: &[TableElement]) -> io::Result<u16> {
         let _ = try!(self.guarantee(1));
 
         loop {

--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -9,6 +9,7 @@ use std::cmp;
 use std::iter::repeat;
 use std::num::wrapping::Wrapping as w;
 use std::io::{self, Read};
+use byteorder::ReadBytesExt;
 
 static LITERALLENGTHCODES: u16 = 286;
 static DISTANCECODES: u16 = 30;

--- a/src/png/encoder.rs
+++ b/src/png/encoder.rs
@@ -7,7 +7,8 @@
 //! are interpreted as signed numbers and summed is chosen as the filter.
 
 use std::slice;
-use std::old_io::*;
+use std::io;
+use std::io::Write;
 use std::num::FromPrimitive;
 use std::iter::repeat;
 
@@ -23,7 +24,7 @@ pub struct PNGEncoder<'a, W: 'a> {
     crc: Crc32
 }
 
-impl<'a, W: Writer> PNGEncoder<'a, W> {
+impl<'a, W: Write> PNGEncoder<'a, W> {
     /// Create a new encoder that writes its output to ```w```
     pub fn new(w: &mut W) -> PNGEncoder<W> {
         PNGEncoder {
@@ -39,7 +40,7 @@ impl<'a, W: Writer> PNGEncoder<'a, W> {
                   image: &[u8],
                   width: u32,
                   height: u32,
-                  c: color::ColorType) -> IoResult<()> {
+                  c: color::ColorType) -> io::Result<()> {
 
         let _ = try!(self.write_signature());
         let (bytes, bpp) = build_ihdr(width, height, c);
@@ -54,11 +55,11 @@ impl<'a, W: Writer> PNGEncoder<'a, W> {
         self.write_chunk("IEND", &[])
     }
 
-    fn write_signature(&mut self) -> IoResult<()> {
+    fn write_signature(&mut self) -> io::Result<()> {
         self.w.write_all(&PNGSIGNATURE)
     }
 
-    fn write_chunk(&mut self, name: &str, buf: &[u8]) -> IoResult<()> {
+    fn write_chunk(&mut self, name: &str, buf: &[u8]) -> io::Result<()> {
         self.crc.reset();
         self.crc.update(name);
         self.crc.update(&buf);
@@ -75,7 +76,7 @@ impl<'a, W: Writer> PNGEncoder<'a, W> {
 }
 
 fn build_ihdr(width: u32, height: u32, c: color::ColorType) -> (Vec<u8>, usize) {
-    let mut m = MemWriter::with_capacity(13);
+    let mut m = Vec::with_capacity(13);
 
     let _ = m.write_be_u32(width);
     let _ = m.write_be_u32(height);

--- a/src/png/zlib.rs
+++ b/src/png/zlib.rs
@@ -5,8 +5,7 @@
 //! # Related Links
 //! *http://tools.ietf.org/html/rfc1950 - ZLIB Compressed Data Format Specification
 
-use std::old_io;
-use std::old_io::*;
+use std::io::{self, Read};
 
 use super::hash::Adler32;
 use super::deflate::Inflater;
@@ -24,7 +23,7 @@ pub struct ZlibDecoder<R> {
     state: ZlibState,
 }
 
-impl<R: Reader> ZlibDecoder<R> {
+impl<R: Read> ZlibDecoder<R> {
     /// Create a new decoder that decodes from a Reader
     pub fn new(r: R) -> ZlibDecoder<R> {
         ZlibDecoder {
@@ -39,7 +38,7 @@ impl<R: Reader> ZlibDecoder<R> {
         self.inflate.inner()
     }
 
-    fn read_header(&mut self) -> IoResult<()> {
+    fn read_header(&mut self) -> io::Result<()> {
         let cmf = try!(self.inner().read_u8());
         let _cm = cmf & 0x0F;
         let _cinfo = cmf >> 4;
@@ -56,7 +55,7 @@ impl<R: Reader> ZlibDecoder<R> {
         Ok(())
     }
 
-    fn read_checksum(&mut self) -> IoResult<()> {
+    fn read_checksum(&mut self) -> io::Result<()> {
         let stream_adler32 = try!(self.inner().read_be_u32());
         let adler32 = self.adler.checksum();
 
@@ -67,8 +66,8 @@ impl<R: Reader> ZlibDecoder<R> {
     }
 }
 
-impl<R: Reader> Reader for ZlibDecoder<R> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+impl<R: Read> Read for ZlibDecoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.state {
             ZlibState::CompressedData => {
                 match self.inflate.read(buf) {
@@ -93,7 +92,7 @@ impl<R: Reader> Reader for ZlibDecoder<R> {
                 self.read(buf)
             }
 
-            ZlibState::End => Err(old_io::standard_error(old_io::EndOfFile))
+            ZlibState::End => Ok(0)
         }
     }
 }

--- a/src/png/zlib.rs
+++ b/src/png/zlib.rs
@@ -6,6 +6,7 @@
 //! *http://tools.ietf.org/html/rfc1950 - ZLIB Compressed Data Format Specification
 
 use std::io::{self, Read};
+use byteorder::{ReadBytesExt, BigEndian};
 
 use super::hash::Adler32;
 use super::deflate::Inflater;
@@ -46,7 +47,7 @@ impl<R: Read> ZlibDecoder<R> {
         let flg = try!(self.inner().read_u8());
         let fdict  = (flg & 0b100000) != 0;
         if fdict {
-            let _dictid = try!(self.inner().read_be_u32());
+            let _dictid = try!(self.inner().read_u32::<BigEndian>());
             panic!("invalid png: zlib detected fdict true")
         }
 
@@ -56,7 +57,7 @@ impl<R: Read> ZlibDecoder<R> {
     }
 
     fn read_checksum(&mut self) -> io::Result<()> {
-        let stream_adler32 = try!(self.inner().read_be_u32());
+        let stream_adler32 = try!(self.inner().read_u32::<BigEndian>());
         let adler32 = self.adler.checksum();
 
         assert!(adler32 == stream_adler32);

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -36,7 +36,7 @@ impl<'a, W: Write> PPMEncoder<'a, W> {
     }
 
     fn write_magic_number(&mut self) -> io::Result<()> {
-        self.w.write_str("P6\n")
+        write!(self.w, "P6\n")
     }
 
     fn write_metadata(&mut self, width: u32, height: u32, pixel_type: color::ColorType) -> io::Result<()> {
@@ -44,7 +44,7 @@ impl<'a, W: Write> PPMEncoder<'a, W> {
         let h = fmt::radix(height, 10);
         let m = max_pixel_value(pixel_type);
 
-        self.w.write_str(&format!("{0} {1}\n{2}\n", w, h, m))
+        write!(self.w, "{0} {1}\n{2}\n", w, h, m)
     }
 
     fn write_image(
@@ -58,9 +58,9 @@ impl<'a, W: Write> PPMEncoder<'a, W> {
         match pixel_type {
             Gray(8) => {
                 for i in (0..(width * height) as usize) {
-                    let _ = try!(self.w.write_u8(buf[i]));
-                    let _ = try!(self.w.write_u8(buf[i]));
-                    let _ = try!(self.w.write_u8(buf[i]));
+                    let _ = try!(self.w.write_all(&[buf[i]]));
+                    let _ = try!(self.w.write_all(&[buf[i]]));
+                    let _ = try!(self.w.write_all(&[buf[i]]));
                 }
             }
 
@@ -69,11 +69,11 @@ impl<'a, W: Write> PPMEncoder<'a, W> {
             RGBA(8) => {
                 for x in buf.chunks(4) {
 
-                    let _ = try!(self.w.write_u8(x[0]));
+                    let _ = try!(self.w.write_all(&[x[0]]));
 
-                    let _ = try!(self.w.write_u8(x[1]));
+                    let _ = try!(self.w.write_all(&[x[1]]));
 
-                    let _ = try!(self.w.write_u8(x[2]));
+                    let _ = try!(self.w.write_all(&[x[2]]));
                 }
             }
 

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -1,6 +1,7 @@
 //! Encoding of PPM Images
 
-use std::old_io::*;
+use std::io;
+use std::io::Write;
 use std::fmt;
 
 use color;
@@ -17,7 +18,7 @@ pub struct PPMEncoder<'a, W: 'a> {
     w: &'a mut W
 }
 
-impl<'a, W: Writer> PPMEncoder<'a, W> {
+impl<'a, W: Write> PPMEncoder<'a, W> {
     /// Create a new PPMEncoder from the Writer ```w```.
     /// This function takes ownership of the Writer.
     pub fn new(w: &mut W) -> PPMEncoder<W> {
@@ -27,18 +28,18 @@ impl<'a, W: Writer> PPMEncoder<'a, W> {
     /// Encode the buffer ```im``` as a PPM image.
     /// ```width``` and ```height``` are the dimensions of the buffer.
     /// ```color``` is the buffers ColorType.
-    pub fn encode(&mut self, im: &[u8], width: u32, height: u32, color: color::ColorType) -> IoResult<()> {
+    pub fn encode(&mut self, im: &[u8], width: u32, height: u32, color: color::ColorType) -> io::Result<()> {
         let _ = try!(self.write_magic_number());
         let _ = try!(self.write_metadata(width, height, color));
 
         self.write_image(im, color, width, height)
     }
 
-    fn write_magic_number(&mut self) -> IoResult<()> {
+    fn write_magic_number(&mut self) -> io::Result<()> {
         self.w.write_str("P6\n")
     }
 
-    fn write_metadata(&mut self, width: u32, height: u32, pixel_type: color::ColorType) -> IoResult<()> {
+    fn write_metadata(&mut self, width: u32, height: u32, pixel_type: color::ColorType) -> io::Result<()> {
         let w = fmt::radix(width, 10);
         let h = fmt::radix(height, 10);
         let m = max_pixel_value(pixel_type);
@@ -51,7 +52,7 @@ impl<'a, W: Writer> PPMEncoder<'a, W> {
         buf: &[u8],
         pixel_type: color::ColorType,
         width: u32,
-        height: u32) -> IoResult<()> {
+        height: u32) -> io::Result<()> {
 
         assert!(buf.len() > 0);
         match pixel_type {

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::io::{Read, Seek};
+use byteorder::{ReadBytesExt, LittleEndian};
 
 use image::ImageError;
 use image::ImageResult;
@@ -112,13 +113,13 @@ impl Header {
             id_length:         try!(r.read_u8()),
             map_type:          try!(r.read_u8()),
             image_type:        try!(r.read_u8()),
-            map_origin:        try!(r.read_le_u16()),
-            map_length:        try!(r.read_le_u16()),
+            map_origin:        try!(r.read_u16::<LittleEndian>()),
+            map_length:        try!(r.read_u16::<LittleEndian>()),
             map_entry_size:    try!(r.read_u8()),
-            x_origin:          try!(r.read_le_u16()),
-            y_origin:          try!(r.read_le_u16()),
-            image_width:       try!(r.read_le_u16()),
-            image_height:      try!(r.read_le_u16()),
+            x_origin:          try!(r.read_u16::<LittleEndian>()),
+            y_origin:          try!(r.read_u16::<LittleEndian>()),
+            image_width:       try!(r.read_u16::<LittleEndian>()),
+            image_height:      try!(r.read_u16::<LittleEndian>()),
             pixel_depth:       try!(r.read_u8()),
             image_desc:        try!(r.read_u8()),
         })
@@ -139,7 +140,12 @@ impl ColorMap {
                        bits_per_entry: u8)
         -> ImageResult<ColorMap> {
             let bytes_per_entry = (bits_per_entry as usize + 7) / 8;
-            let bytes = try!(r.read_exact(bytes_per_entry * num_entries as usize));
+
+            let mut bytes = vec![0; bytes_per_entry * num_entries as usize];
+            if try!(r.read(&mut bytes)) != bytes.len() {
+                return Err(ImageError::ImageEnd);
+            }
+
             Ok(ColorMap {
                 entry_size: bytes_per_entry,
                 start_offset: start_offset as usize,
@@ -300,7 +306,9 @@ impl<R: Read + Seek> TGADecoder<R> {
             try!(self.read_encoded_data())
         } else {
             let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
-            try!(self.r.read_exact(num_raw_bytes))
+            let mut buf = Vec::with_capacity(num_raw_bytes);
+            try!(self.r.by_ref().take(num_raw_bytes as u64).read_to_end(&mut buf));
+            buf
         };
 
         // expand the indices using the color map if necessary
@@ -328,7 +336,8 @@ impl<R: Read + Seek> TGADecoder<R> {
             if (run_packet & 0x80) != 0 {
                 // high bit set, so we will repeat the data
                 let repeat_count = ((run_packet & !0x80) + 1) as usize;
-                let data = try!(self.r.read_exact(self.bytes_per_pixel));
+                let mut data = Vec::with_capacity(self.bytes_per_pixel);
+                try!(self.r.by_ref().take(self.bytes_per_pixel as u64).read_to_end(&mut data));
                 for _ in (0usize..repeat_count) {
                     pixel_data.push_all(&data);
                 }
@@ -336,8 +345,7 @@ impl<R: Read + Seek> TGADecoder<R> {
             } else {
                 // not set, so `run_packet+1` is the number of non-encoded bytes
                 let num_raw_bytes = (run_packet + 1) as usize * self.bytes_per_pixel;
-                let data = try!(self.r.read_exact(num_raw_bytes));
-                pixel_data.push_all(&data);
+                try!(self.r.by_ref().take(num_raw_bytes as u64).read_to_end(&mut pixel_data));
                 num_read += run_packet as usize;
             }
         }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -1,5 +1,5 @@
-use std::old_io;
-use std::old_io::*;
+use std::io;
+use std::io::{Read, Seek};
 
 use image::ImageError;
 use image::ImageResult;
@@ -107,7 +107,7 @@ impl Header {
     }
 
     /// Load the header with values from the reader
-    fn from_reader(r: &mut Reader) -> ImageResult<Header> {
+    fn from_reader(r: &mut Read) -> ImageResult<Header> {
         Ok(Header {
             id_length:         try!(r.read_u8()),
             map_type:          try!(r.read_u8()),
@@ -133,7 +133,7 @@ struct ColorMap {
 }
 
 impl ColorMap {
-    pub fn from_reader(r: &mut Reader,
+    pub fn from_reader(r: &mut Read,
                        start_offset: u16,
                        num_entries: u16,
                        bits_per_entry: u8)
@@ -170,7 +170,7 @@ pub struct TGADecoder<R> {
     color_map: Option<ColorMap>,
 }
 
-impl<R: Reader + Seek> TGADecoder<R> {
+impl<R: Read + Seek> TGADecoder<R> {
     /// Create a new decoder that decodes from the stream `r`
     pub fn new(r: R) -> TGADecoder<R> {
         TGADecoder {
@@ -251,7 +251,7 @@ impl<R: Reader + Seek> TGADecoder<R> {
     /// We're not interested in this field, so this function skips it if it
     /// is present
     fn read_image_id(&mut self) -> ImageResult<()> {
-        try!(self.r.seek(self.header.id_length as i64, old_io::SeekCur));
+        try!(self.r.seek(io::SeekFrom::Current(self.header.id_length as i64)));
         Ok(())
     }
 
@@ -371,7 +371,7 @@ impl<R: Reader + Seek> TGADecoder<R> {
     }
 }
 
-impl<R: Reader + Seek> ImageDecoder for TGADecoder<R> {
+impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
     fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
         try!(self.read_metadata());
 

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -1,7 +1,6 @@
 //! Function for reading TIFF tags
 
-use std::old_io;
-use std::old_io::*;
+use std::io::{self, Read, Seek};
 use std::collections::{HashMap};
 use std::iter::range;
 
@@ -144,14 +143,14 @@ impl Entry {
     }
 
     /// Returns a mem_reader for the offset/value field
-    fn r(&self, byte_order: ByteOrder) -> SmartReader<old_io::MemReader> {
+    fn r(&self, byte_order: ByteOrder) -> SmartReader<Vec<u8>> {
         SmartReader::wrap(
-            old_io::MemReader::new(self.offset.to_vec()),
+            self.offset.to_vec(),
             byte_order
         )
     }
 
-    pub fn val<R: Reader + Seek>(&self, decoder: &mut super::TIFFDecoder<R>)
+    pub fn val<R: Read + Seek>(&self, decoder: &mut super::TIFFDecoder<R>)
     -> ::image::ImageResult<Value> {
         let bo = decoder.byte_order();
         match (self.type_, self.count) {

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -143,9 +143,9 @@ impl Entry {
     }
 
     /// Returns a mem_reader for the offset/value field
-    fn r(&self, byte_order: ByteOrder) -> SmartReader<Vec<u8>> {
+    fn r(&self, byte_order: ByteOrder) -> SmartReader<io::Cursor<Vec<u8>>> {
         SmartReader::wrap(
-            self.offset.to_vec(),
+            io::Cursor::new(self.offset.to_vec()),
             byte_order
         )
     }

--- a/src/tiff/stream.rs
+++ b/src/tiff/stream.rs
@@ -1,7 +1,7 @@
 //! All IO functionality needed for TIFF decoding
 
-use std::old_io;
-use std::old_io::*;
+use std::io;
+use std::io::{Read, Seek};
 use utils::{lzw, bitstream};
 
 /// Byte order of the TIFF file.
@@ -15,13 +15,13 @@ pub enum ByteOrder {
 
 
 /// Reader that is aware of the byte order.
-pub trait EndianReader: Reader {
+pub trait EndianReader: Read {
     /// Byte order that should be adhered to
     fn byte_order(&self) -> ByteOrder;
 
     /// Reads an u16
     #[inline(always)]
-    fn read_u16(&mut self) -> IoResult<u16> {
+    fn read_u16(&mut self) -> io::Result<u16> {
         match self.byte_order() {
             ByteOrder::LittleEndian => self.read_le_u16(),
             ByteOrder::BigEndian => self.read_be_u16()
@@ -30,7 +30,7 @@ pub trait EndianReader: Reader {
 
     /// Reads an u32
     #[inline(always)]
-    fn read_u32(&mut self) -> IoResult<u32> {
+    fn read_u32(&mut self) -> io::Result<u32> {
         match self.byte_order() {
             ByteOrder::LittleEndian => self.read_le_u32(),
             ByteOrder::BigEndian => self.read_be_u32()
@@ -40,27 +40,27 @@ pub trait EndianReader: Reader {
 
 /// Reader that decompresses LZW streams
 pub struct LZWReader {
-    buffer: old_io::MemReader,
+    buffer: Vec<u8>,
     byte_order: ByteOrder
 }
 
 impl LZWReader {
     /// Wraps a reader
-    pub fn new<R>(reader: &mut SmartReader<R>) -> IoResult<(usize, LZWReader)> where R: Reader + Seek {
+    pub fn new<R>(reader: &mut SmartReader<R>) -> io::Result<(usize, LZWReader)> where R: Read + Seek {
         let mut buffer = Vec::new();
         let order = reader.byte_order;
         try!(lzw::decode_early_change(bitstream::MsbReader::new(reader), &mut buffer, 8));
         let bytes = buffer.len();
         Ok((bytes, LZWReader {
-            buffer: old_io::MemReader::new(buffer),
+            buffer: buffer,
             byte_order: order
         }))
     }
 }
 
-impl Reader for LZWReader {
+impl Read for LZWReader {
     #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.buffer.read(buf)
     }
 }
@@ -74,12 +74,12 @@ impl EndianReader for LZWReader {
 
 /// Reader that is aware of the byte order.
 #[derive(Debug)]
-pub struct SmartReader<R> where R: Reader + Seek {
+pub struct SmartReader<R> where R: Read + Seek {
     reader: R,
     pub byte_order: ByteOrder
 }
 
-impl<R> SmartReader<R> where R: Reader + Seek {
+impl<R> SmartReader<R> where R: Read + Seek {
     /// Wraps a reader
     pub fn wrap(reader: R, byte_order: ByteOrder) -> SmartReader<R> {
         SmartReader {
@@ -89,47 +89,23 @@ impl<R> SmartReader<R> where R: Reader + Seek {
     }
 }
 
-impl<R> EndianReader for SmartReader<R> where R: Reader + Seek {
+impl<R> EndianReader for SmartReader<R> where R: Read + Seek {
     #[inline(always)]
     fn byte_order(&self) -> ByteOrder {
         self.byte_order
     }
 }
 
-impl<R: Reader + Seek> Reader for SmartReader<R> {
+impl<R: Read + Seek> Read for SmartReader<R> {
     #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.reader.read(buf)
     }
 }
 
-impl<R: Reader + Seek> Seek for SmartReader<R> {
+impl<R: Read + Seek> Seek for SmartReader<R> {
     #[inline]
-    fn tell(&self) -> IoResult<u64> {
-        self.reader.tell()
-    }
-
-    #[inline]
-    fn seek(&mut self, pos: i64, style: old_io::SeekStyle) -> IoResult<()> {
-        self.reader.seek(pos, style)
-    }
-}
-
-impl<'a, R: Reader + Seek> Reader for &'a mut SmartReader<R> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        self.reader.read(buf)
-    }
-}
-
-impl<'a, R: Reader + Seek> Seek for &'a mut SmartReader<R> {
-    #[inline]
-    fn tell(&self) -> IoResult<u64> {
-        self.reader.tell()
-    }
-
-    #[inline]
-    fn seek(&mut self, pos: i64, style: old_io::SeekStyle) -> IoResult<()> {
-        self.reader.seek(pos, style)
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.reader.seek(pos)
     }
 }

--- a/src/utils/lzw.rs
+++ b/src/utils/lzw.rs
@@ -126,7 +126,7 @@ where R: BitReader, W: Write {
         } else {
             let next_code = table.next_code();
             if prev.is_none() {
-                try!(w.write_u8(code as u8));
+                try!(w.write_all(&[code as u8]));
             } else {
                 let data = if code == next_code {
                     let cha = try!(table.reconstruct(prev))[0];
@@ -279,7 +279,8 @@ where R: Read, W: BitWriter {
     let mut i = None;
     // gif spec: first clear code
     try!(w.write_bits(dict.clear_code(), code_size));
-    while let Ok(c) = r.read_byte() {
+    let r = r.bytes();
+    while let Some(Ok(c)) = r.next() {
         let prev = i;
         i = dict.search_and_insert(prev, c);
         if i.is_none() {

--- a/src/utils/lzw.rs
+++ b/src/utils/lzw.rs
@@ -279,7 +279,7 @@ where R: Read, W: BitWriter {
     let mut i = None;
     // gif spec: first clear code
     try!(w.write_bits(dict.clear_code(), code_size));
-    let r = r.bytes();
+    let mut r = r.bytes();
     while let Some(Ok(c)) = r.next() {
         let prev = i;
         i = dict.search_and_insert(prev, c);

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -1,5 +1,6 @@
 use std::slice;
-use std::old_io::*;
+use std::io;
+use std::io::Read;
 use std::default::Default;
 
 use image;
@@ -21,7 +22,7 @@ pub struct WebpDecoder<R> {
     decoded_rows: u32,
 }
 
-impl<R: Reader> WebpDecoder<R> {
+impl<R: Read> WebpDecoder<R> {
     /// Create a new WebpDecoder from the Reader ```r```.
     /// This function takes ownership of the Reader.
     pub fn new(r: R) -> WebpDecoder<R> {
@@ -65,7 +66,7 @@ impl<R: Reader> WebpDecoder<R> {
 
     fn read_frame(&mut self) -> ImageResult<()> {
         let framedata = try!(self.r.read_to_end());
-        let m = MemReader::new(framedata);
+        let m = io::Cursor::new(framedata);
 
         let mut v = VP8Decoder::new(m);
         let frame = try!(v.decode_frame());
@@ -88,7 +89,7 @@ impl<R: Reader> WebpDecoder<R> {
     }
 }
 
-impl<R: Reader> ImageDecoder for WebpDecoder<R> {
+impl<R: Read> ImageDecoder for WebpDecoder<R> {
     fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
         let _ = try!(self.read_metadata());
 

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -12,7 +12,8 @@
 //! of the VP8 format
 //!
 
-use std::old_io::*;
+use std::io;
+use std::io::Read;
 use std::default::Default;
 use std::iter::repeat;
 
@@ -829,7 +830,7 @@ pub struct VP8Decoder<R> {
     left_border: Vec<u8>,
 }
 
-impl<R: Reader> VP8Decoder<R> {
+impl<R: Read> VP8Decoder<R> {
     /// Create a new decoder.
     /// The reader must present a raw vp8 bitstream to the decoder
     pub fn new(r: R) -> VP8Decoder<R> {
@@ -890,7 +891,7 @@ impl<R: Reader> VP8Decoder<R> {
         }
     }
 
-    fn init_partitions(&mut self, n: usize) -> IoResult<()> {
+    fn init_partitions(&mut self, n: usize) -> io::Result<()> {
         if n > 1 {
             let sizes = try!(self.r.read_exact(3 * n - 3));
 
@@ -1019,7 +1020,7 @@ impl<R: Reader> VP8Decoder<R> {
         }
     }
 
-    fn read_frame_header(&mut self) -> IoResult<()> {
+    fn read_frame_header(&mut self) -> io::Result<()> {
         let mut tag = [0u8; 3];
         let _ = try!(self.r.read(&mut tag));
 
@@ -1385,7 +1386,7 @@ impl<R: Reader> VP8Decoder<R> {
     }
 
     /// Decodes the current frame and returns a reference to it
-    pub fn decode_frame(&mut self) -> IoResult<&Frame> {
+    pub fn decode_frame(&mut self) -> io::Result<&Frame> {
         let _ = try!(self.read_frame_header());
 
         for mby in (0..self.mbheight as usize) {

--- a/tests/tga.rs
+++ b/tests/tga.rs
@@ -1,13 +1,13 @@
-#![feature(old_io, old_path)]
 #![cfg(feature = "tga")]
 
 extern crate image;
 
-use std::old_io::{fs, File, USER_RWX};
+use std::fs::{self, File};
+use std::path::Path;
 
 #[test]
 fn test_open_and_save_tga() {
-    let _ = fs::mkdir(&Path::new("./tests/output"), USER_RWX);
+    let _ = fs::create_dir(&Path::new("./tests/output"));
     let path = Path::new("./tests/images/tga/testsuite/ctc24.tga");
     let img = image::open(&path).unwrap();
     let ref mut fout = File::create(&Path::new("./tests/output/tga-ctc24.png")).unwrap();


### PR DESCRIPTION
Three and a half hour of work, but it's there!

I started from scratch, as this approach was probably easier than rebasing #321 

It adds a dependency to the `byteorder` crate, which provides equivalents to `read_le_u16` and similar.