### PR TITLE
PathBuf::new -> PathBuf::from

### DIFF
--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -1,4 +1,7 @@
 //! An example of opening an image.
+
+#![feature(convert)]
+
 extern crate image;
 
 use std::env;
@@ -16,7 +19,7 @@ fn main() {
 
     // Use the open function to load an image from a PAth.
     // ```open``` returns a dynamic image.
-    let im = image::open(&PathBuf::new(file.clone())).unwrap();
+    let im = image::open(&PathBuf::from(file.clone())).unwrap();
 
     // The dimensions method returns the images width and height
     println!("dimensions {:?}", im.dimensions());
@@ -24,7 +27,7 @@ fn main() {
     // The color method returns the image's ColorType
     println!("{:?}", im.color());
 
-    let ref mut fout = File::create(&PathBuf::new(format!("{}.png", file))).unwrap();
+    let ref mut fout = File::create(&PathBuf::from(format!("{}.png", file))).unwrap();
 
     // Write the contents of this image to the Writer in PNG format.
     let _ = im.save(fout, image::PNG).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![deny(missing_copy_implementations)]
 #![feature(core)]
 #![feature(collections)]
+#![feature(convert)]
 #![feature(io)]
 #![feature(old_path)]
 #![feature(std_misc)]

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -634,10 +634,10 @@ mod tests {
     /// Filters the testsuite images for certain features
     fn get_testimages(feature: &str, color_type: &str, test_interlaced: bool) -> Vec<PathBuf> {
         // Find the files matching "./src/png/testdata/pngsuite/*.png".
-        let pattern = PathBuf::new(".").join("src").join("png").join("testdata").join("pngsuite").join("*.png");
+        let pattern = PathBuf::from(".").join("src").join("png").join("testdata").join("pngsuite").join("*.png");
 
         let paths = glob::glob(&format!("{}", pattern.display())).unwrap()
-            .filter_map(|p| p.ok().map(|p| PathBuf::new(p.to_str().unwrap())))
+            .filter_map(|p| p.ok().map(|p| PathBuf::from(p.to_str().unwrap())))
             .filter(|ref p| p.file_name().and_then(|s| s.to_str()).unwrap().starts_with(feature))
             .filter(|ref p| p.file_name().and_then(|s| s.to_str()).unwrap().contains(color_type));
 
@@ -655,7 +655,7 @@ mod tests {
         ret
     }
 
-    fn load_image<P>(path: P) -> ImageResult<DecodingResult> where P: AsPath {
+    fn load_image(path: &PathBuf) -> ImageResult<DecodingResult> {
         PNGDecoder::new(try!(File::open(path))).read_image()
     }
 
@@ -764,7 +764,7 @@ mod tests {
     fn bench_read_big_file(b: &mut test::Bencher) {
         let mut image_data = Vec::new();
         File::open(
-            &PathBuf::new(".").join("examples").join("fractal.png")
+            &PathBuf::from(".").join("examples").join("fractal.png")
         ).unwrap().read_to_end(&mut image_data).unwrap();
         b.iter(|| {
             let image_data = io::Cursor::new(image_data.clone());


### PR DESCRIPTION
Fixes test compilation failures. One test still failing from an overflow on a shift operation, however..