### PR TITLE
Resolve warnings for latest nightly

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,7 +2,6 @@ use std::slice::{ Chunks, ChunksMut };
 use std::any::TypeId;
 use std::ops::{ Deref, DerefMut, Index, IndexMut };
 use std::marker::{ Reflect, PhantomData };
-use std::num::Int;
 use std::iter::repeat;
 use std::path::Path;
 use std::io;

--- a/src/gif/encoder.rs
+++ b/src/gif/encoder.rs
@@ -5,7 +5,6 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::io;
 use std::io::Write;
 use byteorder::{WriteBytesExt, LittleEndian};
-use std::num::Int;
 
 use buffer::{ImageBuffer, Pixel};
 use color::{Rgb, Rgba};
@@ -58,13 +57,14 @@ where Container: Deref<Target=[u8]> + DerefMut {
 
     /// Encodes the image
     pub fn encode<W: Write>(&mut self, w: &mut W) -> io::Result<()> {
+        use std::u16;
         // Header
         try!(w.write_all(b"GIF89a"));
         // Logical screen descriptor
         let height = self.image.height();
         let width = self.image.width();
-        if width > <u16 as Int>::max_value() as u32 ||
-           height > <u16 as Int>::max_value() as u32 {
+        if width > u16::MAX as u32 ||
+           height > u16::MAX as u32 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "Image dimensions are too large for the gif format.",

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -3,9 +3,7 @@ use std::slice;
 use std::io::Read;
 use std::default::Default;
 use std::collections::vec_map::VecMap;
-use std::num::Float;
 use std::iter::repeat;
-use std::num::wrapping::WrappingOps;
 use byteorder::{ReadBytesExt, BigEndian};
 
 use color;

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -1,7 +1,6 @@
 use std::iter::repeat;
 use std::io::Read;
 use byteorder::ReadBytesExt;
-use std::num::wrapping::WrappingOps;
 
 use image;
 use image::ImageResult;

--- a/src/jpeg/transform.rs
+++ b/src/jpeg/transform.rs
@@ -1,5 +1,3 @@
-use std::num::wrapping::WrappingOps;
-
 // The forward dct's output coefficients are scaled by 8
 // The inverse dct's output samples are clamped to the range [0, 255]
 fn level_shift_up(a: i32) -> u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,9 @@
 #![deny(missing_copy_implementations)]
 #![feature(core)]
 #![feature(collections)]
-#![feature(io)]
 #![feature(std_misc)]
 #![feature(rustc_private)]
 #![feature(step_by)]
-#![feature(convert)]
 #![feature(slice_patterns)]
 #![cfg_attr(test, feature(test))]
 

--- a/src/math/nq.rs
+++ b/src/math/nq.rs
@@ -30,7 +30,6 @@
  *
  */
 
-use std::num::Float;
 use std::cmp::{
     max,
     min
@@ -184,7 +183,9 @@ impl NeuQuant {
     /// for frequently chosen neurons, freq[i] is high and bias[i] is negative
     /// bias[i] = gamma*((1/self.netsize)-freq[i])
     fn contest (&mut self, b: f64, g: f64, r: f64, a: f64) -> i32 {
-        let mut bestd = Float::max_value();
+        use std::f64;
+
+        let mut bestd = f64::MAX;
         let mut bestbiasd: f64 = bestd;
         let mut bestpos = -1;
         let mut bestbiaspos: i32 = bestpos;

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -1,4 +1,3 @@
-use std::num::SignedInt;
 use std::num::Wrapping as w;
 
 #[derive(FromPrimitive, Debug)]

--- a/src/ppm/encoder.rs
+++ b/src/ppm/encoder.rs
@@ -85,8 +85,6 @@ impl<'a, W: Write> PPMEncoder<'a, W> {
 }
 
 fn max_pixel_value(pixel_type: color::ColorType) -> u16 {
-    use std::num::Int;
-
     match pixel_type {
         Gray(n)    => 2u16.pow(n as u32) - 1,
         RGB(n)     => 2u16.pow(n as u32) - 1,

--- a/src/tiff/decoder.rs
+++ b/src/tiff/decoder.rs
@@ -1,8 +1,9 @@
 use std::io::{self, Read, Seek};
 use std::mem;
-use std::num::{ Int, Float, FromPrimitive };
+use std::num::FromPrimitive;
 use std::collections::HashMap;
 use byteorder;
+use num;
 
 use image;
 use image::{
@@ -77,7 +78,11 @@ pub struct TIFFDecoder<R> where R: Read + Seek {
     compression_method: CompressionMethod
 }
 
-fn rev_hpredict_nsamp<T: Int>(mut image: Vec<T>, size: (u32, u32), samples: usize) -> Vec<T> {
+fn rev_hpredict_nsamp<T>(mut image: Vec<T>,
+                         size: (u32, u32),
+                         samples: usize)
+                         -> Vec<T>
+                         where T: num::Num + Copy {
     let width = size.0 as usize;
     let height = size.1 as usize;
     for row in (0..height) {

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -1,10 +1,8 @@
 //! Compares the decoding results with reference renderings.
-#![feature(core)] 
 
 use std::fs;
-use std::num;
+use std::u32;
 use std::path::PathBuf;
-
 
 extern crate image;
 extern crate glob;
@@ -13,7 +11,6 @@ const BASE_PATH: [&'static str; 2] = [".", "tests"];
 const IMAGE_DIR: &'static str = "images";
 const OUTPUT_DIR: &'static str = "output";
 const REFERENCE_DIR: &'static str = "reference";
-
 
 fn process_images<F>(dir: &str, input_decoder: Option<&str>, func: F)
 where F: Fn(&PathBuf, PathBuf, &str) {
@@ -94,7 +91,7 @@ fn check_references() {
 			.split(".").take(2)
 			.collect::<Vec<_>>().connect(".")
 		);
-        let ref_crc = num::from_str_radix(filename
+        let ref_crc = u32::from_str_radix(filename
             .as_os_str()
             .to_str().unwrap()
             .split(".").nth(2).unwrap(), 16


### PR DESCRIPTION
The crate now compiles without warnings again. For the most part, this deals with `num::Int` et al. being deprecated.