### PR TITLE
Stop relying on implementation defined structure layout.

### DIFF
--- a/src/gif/encoder.rs
+++ b/src/gif/encoder.rs
@@ -39,7 +39,7 @@ pub struct Encoder<Image> {
     color_mode: ColorMode
 }
 
-const TRANSPARENT: Rgba<u8> = Rgba([0, 0, 0, 0]);
+const TRANSPARENT: Rgba<u8> = Rgba {data: [0, 0, 0, 0]};
 
 impl<Container> Encoder<ImageBuffer<Rgba<u8>, Container>>
 where Container: Deref<Target=[u8]> + DerefMut {

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -136,7 +136,7 @@ impl ColorMap for BiLevel {
 
     #[inline(always)]
     fn index_of(&self, color: &Luma<u8>) -> usize {
-        let &Luma(luma) = color;
+        let luma = color.data;
         if luma[0] > 127 {
             1
         } else {
@@ -147,7 +147,7 @@ impl ColorMap for BiLevel {
     #[inline(always)]
     fn map_color(&self, color: &mut Luma<u8>) {
         let new_color = 0xFF * self.index_of(color) as u8;
-        let &mut Luma(ref mut luma) = color;
+        let luma = &mut color.data;
         luma[0] = new_color;
     }
 }


### PR DESCRIPTION
Rust does not make any guarantees about how tuple structs are layed out in memory. Using C-type-structs mediates this potential future problem.