### PR TITLE
Remove some feature gates

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -391,8 +391,10 @@ impl<T: Primitive> Blend for LumaA<T> {
     fn blend(&mut self, other: &LumaA<T>) {
         let max_t: T = Primitive::max_value();
         let max_t = max_t.to_f32().unwrap();
-        let &mut LumaA([bg_luma, bg_a]) = self;
-        let &LumaA([fg_luma, fg_a]) = other;
+
+        let (bg_luma, bg_a) = match self { &mut LumaA(ref d) => (d[0], d[1]) };
+        let (fg_luma, fg_a) = match other { &LumaA(ref d) => (d[0], d[1]) };
+
         let (bg_luma, bg_a) = (bg_luma.to_f32().unwrap() / max_t, bg_a.to_f32().unwrap() / max_t);
         let (fg_luma, fg_a) = (fg_luma.to_f32().unwrap() / max_t, fg_a.to_f32().unwrap() / max_t);
 
@@ -423,8 +425,8 @@ impl<T: Primitive> Blend for Rgba<T> {
         // First, as we don't know what type our pixel is, we have to convert to floats between 0.0 and 1.0
         let max_t: T = Primitive::max_value();
         let max_t = max_t.to_f32().unwrap();
-        let &mut Rgba([bg_r, bg_g, bg_b, bg_a]) = self;
-        let &Rgba([fg_r, fg_g, fg_b, fg_a]) = other;
+        let (bg_r, bg_g, bg_b, bg_a) = match self { &mut Rgba(ref d) => (d[0], d[1], d[2], d[3]) };
+        let (fg_r, fg_g, fg_b, fg_a) = match other { &Rgba(ref d) => (d[0], d[1], d[2], d[3]) };
         let (bg_r, bg_g, bg_b, bg_a) = (bg_r.to_f32().unwrap() / max_t, bg_g.to_f32().unwrap() / max_t, bg_b.to_f32().unwrap() / max_t, bg_a.to_f32().unwrap() / max_t);
         let (fg_r, fg_g, fg_b, fg_a) = (fg_r.to_f32().unwrap() / max_t, fg_g.to_f32().unwrap() / max_t, fg_b.to_f32().unwrap() / max_t, fg_a.to_f32().unwrap() / max_t);
 
@@ -465,20 +467,20 @@ pub trait Invert {
 
 impl<T: Primitive> Invert for LumaA<T> {
     fn invert(&mut self) {
-        let &mut LumaA([l, a]) = self;
+        let &mut LumaA(l) = self;
         let max: T = Primitive::max_value();
 
-        *self = LumaA([max - l, a])
+        *self = LumaA([max - l[0], l[1]])
 
     }
 }
 
 impl<T: Primitive> Invert for Luma<T> {
     fn invert(&mut self) {
-        let &mut Luma([l]) = self;
+        let &mut Luma(l) = self;
 
         let max: T = Primitive::max_value();
-        let l1 = max - l;
+        let l1 = max - l[0];
 
         *self = Luma([l1])
     }
@@ -486,23 +488,23 @@ impl<T: Primitive> Invert for Luma<T> {
 
 impl<T: Primitive> Invert for Rgba<T> {
     fn invert(&mut self) {
-        let &mut Rgba([r, g, b, a]) = self;
+        let &mut Rgba(rgba) = self;
 
         let max: T = Primitive::max_value();
 
-        *self = Rgba([max - r, max - g, max - b, a])
+        *self = Rgba([max - rgba[0], max - rgba[1], max - rgba[2], rgba[3]])
     }
 }
 
 impl<T: Primitive> Invert for Rgb<T> {
     fn invert(&mut self) {
-        let &mut Rgb([r, g, b]) = self;
+        let &mut Rgb(rgb) = self;
 
         let max: T = Primitive::max_value();
 
-        let r1 = max - r;
-        let g1 = max - g;
-        let b1 = max - b;
+        let r1 = max - rgb[0];
+        let g1 = max - rgb[1];
+        let b1 = max - rgb[2];
 
         *self = Rgb([r1, g1, b1])
     }

--- a/src/gif/encoder.rs
+++ b/src/gif/encoder.rs
@@ -161,18 +161,18 @@ where Container: Deref<Target=[u8]> + DerefMut {
                         bg_index = i;
                     }
                 }
-                table.push_all(channels)
+                table.extend(channels.iter().map(|&c| c))
             }
             // Waste some space as of gif spec
             for _ in 0..((2 << n) - num_colors) {
-                table.push_all(&[0, 0, 0]);
+                table.extend([0, 0, 0].iter().map(|&c| c));
             }
             (Some(table), bg_index as u8)
         } else if let Some(bg_color) = self.bg_color {
             flags |= 1 << 7; // glocal table flag
             let mut table = Vec::with_capacity(6);
-            table.push_all(&bg_color.channels()[..3]);
-            table.push_all(&[0, 0, 0]);
+            table.extend(bg_color.channels().iter().take(3).map(|&c| c));
+            table.extend([0, 0, 0].iter().map(|&c| c));
             (Some(table), 0)
         } else {
             (None, 0)

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -136,8 +136,8 @@ impl ColorMap for BiLevel {
 
     #[inline(always)]
     fn index_of(&self, color: &Luma<u8>) -> usize {
-        let &Luma([luma]) = color;
-        if luma > 127 {
+        let &Luma(luma) = color;
+        if luma[0] > 127 {
             1
         } else {
             0
@@ -147,8 +147,8 @@ impl ColorMap for BiLevel {
     #[inline(always)]
     fn map_color(&self, color: &mut Luma<u8>) {
         let new_color = 0xFF * self.index_of(color) as u8;
-        let &mut Luma([ref mut luma]) = color;
-        *luma = new_color;
+        let &mut Luma(ref mut luma) = color;
+        luma[0] = new_color;
     }
 }
 

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -2,7 +2,7 @@ use std::cmp;
 use std::slice;
 use std::io::Read;
 use std::default::Default;
-use std::collections::vec_map::VecMap;
+use std::collections::HashMap;
 use std::iter::repeat;
 use byteorder::{ReadBytesExt, BigEndian};
 
@@ -114,7 +114,7 @@ pub struct JPEGDecoder<R> {
 
     num_components: u8,
     scan_components: Vec<u8>,
-    components: VecMap<Component>,
+    components: HashMap<usize, Component>,     // TODO: replace by `VecMap`
 
     mcu_row: Vec<u8>,
     mcu: Vec<u8>,
@@ -150,7 +150,7 @@ impl<R: Read>JPEGDecoder<R> {
 
             num_components: 0,
             scan_components: Vec::new(),
-            components: VecMap::new(),
+            components: HashMap::new(),
 
             mcu_row: Vec::new(),
             mcu: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![warn(unused_qualifications)]
 #![deny(missing_copy_implementations)]
 #![feature(core)]
-#![feature(collections)]
 #![feature(std_misc)]
 #![feature(rustc_private)]
 #![feature(step_by)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(std_misc)]
 #![feature(rustc_private)]
 #![feature(step_by)]
-#![feature(slice_patterns)]
 #![cfg_attr(test, feature(test))]
 
 extern crate byteorder;

--- a/src/math/nq.rs
+++ b/src/math/nq.rs
@@ -114,26 +114,26 @@ impl NeuQuant {
     /// Maps the pixel in-place to the best-matching color in the color map
     #[inline(always)]
     pub fn map_pixel(&self, pixel: &mut [u8]) {
-        match pixel {
-            [r, g, b, a] => {
+        assert!(pixel.len() == 4);
+        match (pixel[0], pixel[1], pixel[2], pixel[3]) {
+            (r, g, b, a) => {
                 let i = self.inxsearch(b, g, r, a);
                 pixel[0] = self.colormap[i].r as u8;
                 pixel[1] = self.colormap[i].g as u8;
                 pixel[2] = self.colormap[i].b as u8;
                 pixel[3] = self.colormap[i].a as u8;
             }
-            _ => panic!()
         }
     }
 
     /// Finds the best-matching index in the color map for `pixel`
     #[inline(always)]
     pub fn index_of(&self, pixel: &[u8]) -> usize {
-        match pixel {
-            [r, g, b, a] => {
+        assert!(pixel.len() == 4);
+        match (pixel[0], pixel[1], pixel[2], pixel[3]) {
+            (r, g, b, a) => {
                 self.inxsearch(b, g, r, a)
             }
-            _ => panic!()
         }
     }
 

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -294,7 +294,7 @@ impl<R: Read + Seek> TGADecoder<R> {
 
         for chunk in pixel_data.chunks(self.bytes_per_pixel) {
             let index = bytes_to_index(chunk);
-            result.push_all(color_map.get(index));
+            result.extend(color_map.get(index).iter().map(|&c| c));
         }
 
         result
@@ -339,7 +339,7 @@ impl<R: Read + Seek> TGADecoder<R> {
                 let mut data = Vec::with_capacity(self.bytes_per_pixel);
                 try!(self.r.by_ref().take(self.bytes_per_pixel as u64).read_to_end(&mut data));
                 for _ in (0usize..repeat_count) {
-                    pixel_data.push_all(&data);
+                    pixel_data.extend(data.iter().map(|&c| c));
                 }
                 num_read += repeat_count;
             } else {

--- a/src/tiff/decoder.rs
+++ b/src/tiff/decoder.rs
@@ -423,17 +423,36 @@ impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
     }
 
     fn colortype(&mut self) -> ImageResult<ColorType> {
-        match (&*self.bits_per_sample, self.photometric_interpretation) {
-            // TODO: catch also [ 8,  8,  8, _] this does not work due to a bug in rust atm
-            ([ 8,  8,  8, 8],  PhotometricInterpretation::RGB) => Ok(ColorType::RGBA(8)),
-            ([ 8,  8,  8],     PhotometricInterpretation::RGB) => Ok(ColorType::RGB(8)),
-            ([16, 16, 16, 16], PhotometricInterpretation::RGB) => Ok(ColorType::RGBA(16)),
-            ([16, 16, 16],     PhotometricInterpretation::RGB) => Ok(ColorType::RGB(16)),
-            ([ n], PhotometricInterpretation::BlackIsZero)
-            |([ n], PhotometricInterpretation::WhiteIsZero) => Ok(ColorType::Gray(n)),
-            (bits, mode) => return Err(::image::ImageError::UnsupportedError(format!(
-                "{:?} with {:?} bits per sample is unsupported", mode, bits
-            ))) // TODO: this is bad we should not fail at this point
+        if self.bits_per_sample == [8, 8, 8, 8] &&
+           self.photometric_interpretation == PhotometricInterpretation::RGB
+        {
+            Ok(ColorType::RGBA(8))
+
+        } else if self.bits_per_sample == [8, 8, 8] &&
+                  self.photometric_interpretation == PhotometricInterpretation::RGB
+        {
+            Ok(ColorType::RGB(8))
+
+        } else if self.bits_per_sample == [16, 16, 16, 16] &&
+                  self.photometric_interpretation == PhotometricInterpretation::RGB
+        {
+            Ok(ColorType::RGBA(16))
+
+        } else if self.bits_per_sample == [16, 16, 16] &&
+                  self.photometric_interpretation == PhotometricInterpretation::RGB
+        {
+            Ok(ColorType::RGB(16))
+
+        } else if self.bits_per_sample.len() == 1 &&
+                  (self.photometric_interpretation == PhotometricInterpretation::BlackIsZero ||
+                   self.photometric_interpretation == PhotometricInterpretation::WhiteIsZero)
+        {
+            Ok(ColorType::Gray(self.bits_per_sample[0]))
+
+        } else {
+            return Err(::image::ImageError::UnsupportedError(format!(
+                "{:?} with {:?} bits per sample is unsupported", self.bits_per_sample, self.photometric_interpretation
+            ))) // TODO: this is bad we should not fail at this point}
         }
     }
 


### PR DESCRIPTION
Remaining features:

 - `core`: 154 compilation errors when I remove this one. Probably fixable, but that's a lot of work.
 - `std_misc`: several small things. Probably fixable too but I don't have time right now.
 - `step_by`: feature-gated function because added recently. Need to check what the plan is for this one. If it's not getting stable, it is possible to write a replacement.
 - `rustc_private`: used for the `flate` library. There is a replacement `flate2` on crates.io, however it's just bindings for miniz.c, which would force users to have a C compiler installed. I don't like this. Probably the most problematic feature.
 - `test`: not sure how to have access to the bencher without this one.
