### PR TITLE
Fix inflate with uncompressed blocks

### DIFF
--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -210,9 +210,7 @@ impl<R: Read> Inflater<R> {
     fn read_stored_block(&mut self) -> io::Result<()> {
         while self.block_length > 0 {
             let a = try!(self.h.receive(8));
-
             self.buf.push(a as u8);
-            self.h.consume(8);
             self.block_length -= 1;
         }
 


### PR DESCRIPTION
Doesn't fix neither #376 nor #300 
Reviewing required, but for me it seems wrong, as `receive` already calls `consume`.