### PR TITLE
Fix PNG decoder with uncompressed blocks

### DIFF
--- a/src/png/deflate.rs
+++ b/src/png/deflate.rs
@@ -40,8 +40,7 @@ impl<W> Deflater<W> where W: Write {
         let nlen = !len;    // one's complement
 
         let writer = self.writer.as_mut().unwrap();
-        try!(writer.write_u8(if last { 0x29 } else { 0 }));       // bits and stuff
-                  // TODO: should be 1  ^, but a bug in the PNGDecoder can be bypassed with 0x29
+        try!(writer.write_u8(if last { 1 } else { 0 }));       // bits and stuff
         try!(writer.write_u16::<LittleEndian>(len));
         try!(writer.write_u16::<LittleEndian>(nlen));
         try!(writer.write_all(&self.buf));

--- a/src/png/inflate.rs
+++ b/src/png/inflate.rs
@@ -377,7 +377,7 @@ impl<R: Read> HuffReader<R> {
     }
 
     pub fn byte_align(&mut self) {
-        let n = self.bits & 0b111;
+        let n = self.num_bits & 0b111;
 
         self.bits >>= n as usize;
         self.num_bits -= n as u8;


### PR DESCRIPTION
Follow-up of #379 

Stupid me didn't realize this was just a typo, and replacing `bits` by `num_bits` is the correct behavior.
