### PR TITLE
Replace #[derive(FromPrimitive)] with the enum_primitive crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ version = "0.3.5"
 [dependencies.num]
 version = "0.1.20"
 
+[dependencies.enum_primitive]
+version = "0.0.1"
+
 [dev-dependencies.glob]
 version = "0.2.9"
 

--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -7,7 +7,7 @@
 
 use std::io::{self, Read};
 use byteorder::{ReadBytesExt, LittleEndian};
-use std::num::FromPrimitive;
+use num::FromPrimitive;
 
 use num::rational::Ratio;
 use imageops::overlay;

--- a/src/gif/mod.rs
+++ b/src/gif/mod.rs
@@ -14,15 +14,16 @@ mod decoder;
 mod encoder;
 
 
-#[derive(FromPrimitive)]
+enum_from_primitive! {
 /// Known block types
 enum Block {
     Image = 0x2C,
     Extension = 0x21,
     Trailer = 0x3B
 }
+}
 
-#[derive(FromPrimitive)]
+enum_from_primitive! {
 /// Known GIF extensions
 enum Extension {
     Text = 0x01,
@@ -30,12 +31,14 @@ enum Extension {
     Comment = 0xFE,
     Application = 0xFF
 }
+}
 
-#[derive(FromPrimitive)]
+enum_from_primitive! {
 /// Method to dispose the image
 enum DisposalMethod {
 	Undefined = 0,
 	None = 1,
 	Previous = 2,
 	Background = 3
+}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 
 extern crate byteorder;
 extern crate num;
+#[macro_use]
+extern crate enum_primitive;
 #[cfg(test)] extern crate test;
 
 pub use color::ColorType as ColorType;

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -1,7 +1,7 @@
 use std::io::{ self, Read };
 use std::{ cmp, iter, str, slice };
 use std::iter::repeat;
-use std::num::FromPrimitive;
+use num::FromPrimitive;
 use byteorder::{ ReadBytesExt, BigEndian };
 use num::range_step;
 
@@ -34,10 +34,12 @@ enum PNGState {
     HaveIEND
 }
 
-#[derive(Clone, Copy, FromPrimitive, Debug, PartialEq)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum InterlaceMethod {
     None = 0,
     Adam7 = 1
+}
 }
 
 /// This iterator iterates over the different passes of an image Adam7 encoded

--- a/src/png/encoder.rs
+++ b/src/png/encoder.rs
@@ -9,7 +9,7 @@
 use std::slice;
 use std::io;
 use std::io::Write;
-use std::num::FromPrimitive;
+use num::FromPrimitive;
 use std::iter::repeat;
 use byteorder::{WriteBytesExt, BigEndian};
 

--- a/src/png/filter.rs
+++ b/src/png/filter.rs
@@ -1,12 +1,14 @@
 use std::num::Wrapping as w;
 
-#[derive(FromPrimitive, Debug)]
+enum_from_primitive! {
+#[derive(Debug)]
 pub enum FilterType {
     NoFilter = 0,
     Sub = 1,
     Up = 2,
     Avg = 3,
     Paeth = 4
+}
 }
 
 fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {

--- a/src/tiff/decoder.rs
+++ b/src/tiff/decoder.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Read, Seek};
 use std::mem;
-use std::num::FromPrimitive;
+use num::FromPrimitive;
 use std::collections::HashMap;
 use byteorder;
 use num;
@@ -26,7 +26,8 @@ use super::stream::{
     LZWReader
 };
 
-#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum PhotometricInterpretation {
     WhiteIsZero = 0,
     BlackIsZero = 1,
@@ -37,8 +38,10 @@ enum PhotometricInterpretation {
     YCbCr = 6,
     CIELab = 8,
 }
+}
 
-#[derive(Clone, Copy, Debug, FromPrimitive)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug)]
 enum CompressionMethod {
     None = 1,
     Huffman = 2,
@@ -48,17 +51,22 @@ enum CompressionMethod {
     JPEG = 6,
     PackBits = 32773
 }
+}
 
-#[derive(Clone, Copy, Debug, FromPrimitive)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug)]
 enum PlanarConfiguration {
     Chunky = 1,
     Planar = 2
 }
+}
 
-#[derive(Clone, Copy, Debug, FromPrimitive)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug)]
 enum Predictor {
     None = 1,
     Horizontal = 2
+}
 }
 
 /// The representation of a PNG decoder

--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -74,13 +74,15 @@ tags!{
     Predictor 317;
 }
 
-#[derive(Clone, Copy, Debug, FromPrimitive)]
+enum_from_primitive! {
+#[derive(Clone, Copy, Debug)]
 pub enum Type {
     BYTE = 1,
     ASCII = 2,
     SHORT = 3,
     LONG = 4,
     RATIONAL = 5,
+}
 }
 
 


### PR DESCRIPTION
The built-in `#[derive(FromPrimitive)]` only works with `std::num::FromPrimitive`, which is still unstable.  This significantly reduces our reliance on `#![feature(core)]`.