### PR TITLE
Finish making "image" compatible with beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ notifications:
 os:
     - linux
     - osx
+rust:
+    - 1.0.0-beta
+    - nightly
 env:
     global:
         - secure: M2MCRtyP5P/Xf2TSqrbz8cs41TQY04mK/5Fi6qgr77OKLNZlDclKiFY8BmQ6f1JhVccoE5gMIFpfPoVUu8wZ0Pe7/X4IyO4vxWawVQfE6f0NYErD9yqiE1KEi/RGKPOQfL5HFUK7ifnXvLwsAMh1ix9XMgaBZfZLQ8KhkxNRXwI=
@@ -19,11 +22,11 @@ env:
 script:
     - if [ -z "$FEATURES" ]; then
         cargo build -v;
-        cargo test -v;
+        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi;
         cargo doc -v;
       else
         cargo build -v --no-default-features --features "$FEATURES";
-        cargo test -v --no-default-features --features "$FEATURES";
+        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi;
         cargo doc -v;
       fi
 after_success: |

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::mem;
 use std::io;
-use std::slice;
 use std::iter::repeat;
 
 use byteorder;
@@ -182,7 +181,7 @@ pub trait ImageDecoder: Sized {
 
                 let to   = &mut buf[i * width as usize * bpp..width as usize * bpp];
 
-                slice::bytes::copy_memory(from, to);
+                ::copy_memory(from, to);
             }
 
             let _ = try!(self.read_scanline(&mut tmp));

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::slice;
 use std::io::Read;
 use std::default::Default;
 use std::collections::HashMap;
@@ -589,7 +588,7 @@ impl<R: Read> ImageDecoder for JPEGDecoder<R> {
         let slice = &self.mcu_row[self.row_count as usize * len..
         self.row_count as usize * len + buf.len()];
 
-        slice::bytes::copy_memory(slice, buf);
+        ::copy_memory(slice, buf);
 
         self.row_count = (self.row_count + 1) % (self.vmax * 8);
         self.decoded_rows += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![crate_name = "image"]
 #![crate_type = "rlib"]
-#![feature(core)]
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(missing_copy_implementations)]
@@ -126,3 +125,20 @@ mod color;
 mod buffer;
 mod traits;
 mod animation;
+
+/// Copies data from `src` to `dst`
+///
+/// Panics if the length of `dst` is less than the length of `src`.
+// NOTE: this is a copy-paste of the unstable function `std::::copy_memory`.
+#[inline]
+pub fn copy_memory(src: &[u8], dst: &mut [u8]) {
+    let len_src = src.len();
+    assert!(dst.len() >= len_src);
+    // `dst` is unaliasable, so we know statically it doesn't overlap
+    // with `src`.
+    unsafe {
+        std::ptr::copy_nonoverlapping(src.as_ptr(),
+                                      dst.as_mut_ptr(),
+                                      len_src);
+    }
+}

--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -1,5 +1,5 @@
 use std::io::{ self, Read };
-use std::{ cmp, str, slice };
+use std::{ cmp, str };
 use std::iter::repeat;
 use num::FromPrimitive;
 use byteorder::{ ReadBytesExt, BigEndian };
@@ -414,7 +414,7 @@ impl<R: Read> PNGDecoder<R> {
         }
 
         unfilter(filter_type, self.bpp as usize, &self.previous, &mut buf[..rlength as usize]);
-        slice::bytes::copy_memory(&buf[..rlength as usize], &mut self.previous);
+        ::copy_memory(&buf[..rlength as usize], &mut self.previous);
 
 
         if let Some(ref palette) = self.palette {

--- a/src/png/encoder.rs
+++ b/src/png/encoder.rs
@@ -6,7 +6,6 @@
 //! For each row the filter method that produces the lowest integer when its bytes
 //! are interpreted as signed numbers and summed is chosen as the filter.
 
-use std::slice;
 use std::io;
 use std::io::Write;
 use num::FromPrimitive;
@@ -155,7 +154,7 @@ fn build_idat(image: &[u8], bpp: usize, width: u32) -> io::Result<Vec<u8>> {
 
     for row in image.chunks(rowlen) {
         for s in c.chunks_mut(rowlen) {
-            slice::bytes::copy_memory(row, s);
+            ::copy_memory(row, s);
         }
 
         let filter = select_filter(rowlen, bpp, &p, &mut c);
@@ -170,7 +169,7 @@ fn build_idat(image: &[u8], bpp: usize, width: u32) -> io::Result<Vec<u8>> {
             }
         }
 
-        slice::bytes::copy_memory(row, &mut p);
+        ::copy_memory(row, &mut p);
     }
 
     e.into_inner()

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -1,4 +1,3 @@
-use std::slice;
 use std::io;
 use std::io::Read;
 use std::default::Default;
@@ -124,7 +123,7 @@ impl<R: Read> ImageDecoder for WebpDecoder<R> {
             self.decoded_rows as usize * rlen + rlen
         ];
 
-        slice::bytes::copy_memory(slice, buf);
+        ::copy_memory(slice, buf);
         self.decoded_rows += 1;
 
         Ok(self.decoded_rows)


### PR DESCRIPTION
I copy-pasted the body of `std::slice::bytes::copy_memory`, the last unstable function that was still in use by "image".

I also added travis testing for the beta (in addition to the nightly). However `cargo test` isn't run for the beta since it uses the unstable bencher.