### PR TITLE
Update the tested version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
     - linux
     - osx
 rust:
-    - 1.0.0-beta
+    - 1.0.0-beta.2
     - nightly
 env:
     global:


### PR DESCRIPTION
The reason for this change is that byteorder is now broken on beta 1.

Ultimately this should be changed to `stable` after 1.0 is released, but this doesn't work yet.