### PR TITLE
JPG overflow fix. Fixes #409

### DIFF
--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -308,8 +308,8 @@ impl<R: Read>JPEGDecoder<R> {
             )))
         }
 
-        self.height 	    = try!(self.r.read_u16::<BigEndian>());
-        self.width  	    = try!(self.r.read_u16::<BigEndian>());
+        self.height         = try!(self.r.read_u16::<BigEndian>());
+        self.width          = try!(self.r.read_u16::<BigEndian>());
         self.num_components = try!(self.r.read_u8());
 
         if self.height == 0 || self.width == 0 {
@@ -671,9 +671,12 @@ fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8) -> (u8, u8, u8) {
 // Section F.2.2.1
 // Figure F.12
 fn extend(v: i32, t: u8) -> i32 {
-let vt:
     // FIXME check if wrapping sub is what we want
-    i32 = 1 << (t as usize).wrapping_sub(1);
+    let mut vt: i32 = 0;
+    let shift = (t as usize).wrapping_sub(1);
+    if shift < 31 {
+        vt = 1 << shift;
+    }
 
     if v < vt {
     v + ((-1) << t as usize) + 1

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -148,9 +148,9 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
 
         // FIXME there is something wrong with this code
         let diff = huffsize[k].wrapping_sub(size);
-        code <<= diff as usize;
-
-        size = size.wrapping_add(diff)
+        code = if diff < 16  { code << diff as usize } else { 0 };
+        
+        size = size.wrapping_add(diff);
     }
 
     (huffsize, huffcode)


### PR DESCRIPTION
On release builds overflows are not checked, on debug builds they are causing Image to panic on certain JPGs. "wrapping_shl" is unstable and not available in Rust Beta so instead this checks if the shift is too large and just sets the value to 0 if it is.