### PR TITLE
Bump to 0.3.10.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.3.9"
+version = "0.3.10"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [


### PR DESCRIPTION
It'd be great to have a new version published now that #410 is fixed and the JPEG decoder doesn't overflow so much.