### PR TITLE
Suggestion: setup coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ os:
 rust:
     - 1.0.0
     - nightly
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev      # for kcov
+    - libelf-dev                # for kcov
+    - libdw-dev                 # for kcov
+    - cmake                     # for kcov
 env:
     global:
         - secure: M2MCRtyP5P/Xf2TSqrbz8cs41TQY04mK/5Fi6qgr77OKLNZlDclKiFY8BmQ6f1JhVccoE5gMIFpfPoVUu8wZ0Pe7/X4IyO4vxWawVQfE6f0NYErD9yqiE1KEi/RGKPOQfL5HFUK7ifnXvLwsAMh1ix9XMgaBZfZLQ8KhkxNRXwI=
@@ -29,11 +36,20 @@ script:
         if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi;
         cargo doc -v;
       fi
-after_success: |
-    [ $TRAVIS_BRANCH = master ] &&
-    [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc &&
-    echo '<meta http-equiv=refresh content=0;url=image/index.html>' > target/doc/index.html &&
-    sudo pip install ghp-import &&
-    ghp-import -n target/doc &&
-    git push -fq https://${GH_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+after_success:
+    - |
+        [ $TRAVIS_BRANCH = master ] &&
+        [ $TRAVIS_PULL_REQUEST = false ] &&
+        cargo doc &&
+        echo '<meta http-equiv=refresh content=0;url=image/index.html>' > target/doc/index.html &&
+        sudo pip install ghp-import &&
+        ghp-import -n target/doc &&
+        git push -fq https://${GH_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+    - |
+        [ $TRAVIS_BRANCH = master ] &&
+        [ $TRAVIS_PULL_REQUEST = false ] &&
+        wget https://github.com/SimonKagstrom/kcov/archive/master.zip &&
+        unzip master.zip && mv kcov-master kcov && mkdir kcov/build && cd kcov/build &&
+        cmake .. && make && make install DESTDIR=../built && cd ../.. &&
+        for file in ./target/debug/*; do ./kcov/built/usr/local/bin/kcov --exclude-pattern=/.cargo ./target/kcov ${file}; done &&
+        ./kcov/built/usr/local/bin/kcov --coveralls-id=${TRAVIS_JOB_ID} --merge ./target/kcov-merge ./target/kcov


### PR DESCRIPTION
The only thing required to get test coverage by coveralls.io is to execute a script on travis and send the result to their website.

It just has to be enabled on the site.