### PR TITLE
Remove unnecessary use of `#[repr(packed)]`.

### DIFF
--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -72,7 +72,6 @@ impl ImageType {
 
 /// Header used by TGA image files
 #[derive(Debug)]
-#[repr(packed)]
 struct Header {
     id_length: u8,         // length of ID string
     map_type: u8,          // color map type


### PR DESCRIPTION
This struct never seems to be used in a way that requires being packed.

The removal is good because there's some correctness issues with it, so
there may be breaking changes to it in future and removing it now will
avoid them all together. See
https://github.com/rust-lang/rust/issues/27060.