### PR TITLE
fix BMP wikipedia URL

### DIFF
--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -4,7 +4,7 @@
 //!
 //!  # Related Links
 //!  * https://msdn.microsoft.com/en-us/library/windows/desktop/dd183375%28v=vs.85%29.aspx
-//!  * en.wikipedia.org/wiki/BMP_file_format
+//!  * https://en.wikipedia.org/wiki/BMP_file_format
 //!
 
 pub use self::decoder::BMPDecoder;


### PR DESCRIPTION
Leaving off the https:// prefix means that it doesn't get auto-linkified
in the docs, which seems unfortunate.