### PR TITLE
run doc only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ script:
     - if [ -z "$FEATURES" ]; then
         cargo build -v;
         if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi;
-        cargo doc -v;
       else
         cargo build -v --no-default-features --features "$FEATURES";
         if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi;
-        cargo doc -v;
       fi
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
+    [ "$TRAVIS_RUST_VERSION" = "nightly" ] &&
+    [ -z "$FEATURES" ] &&
     cargo doc &&
     echo '<meta http-equiv=refresh content=0;url=image/index.html>' > target/doc/index.html &&
     pip install --user ghp-import &&


### PR DESCRIPTION
why run cargo doc for every build?
cargo tests checks the doc-tests and the update to the gh-pages should be from a fix build with fix features
