### PR TITLE
Fix some inaccuracies and spelling/grammar/formatting errors in doc comments

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,7 +2,7 @@ use num::rational::Ratio;
 
 use buffer::RgbaImage;
 
-/// Hold the frames of the animated image
+/// Holds the frames of the animated image
 pub struct Frames {
     frames: Vec<Frame>,
     current_frame: usize,
@@ -71,7 +71,7 @@ impl Frame {
         self.left
     }
 
-    /// Returns the x offset
+    /// Returns the y offset
     pub fn top(&self) -> u32 {
         self.top
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -37,11 +37,13 @@ pub trait Pixel: Copy + Clone {
 
     /// Returns the channels of this pixel as a 4 tuple. If the pixel
     /// has less than 4 channels the remainder is filled with the maximum value
+    ///
     /// TODO deprecate
     fn channels4(&self) -> (Self::Subpixel, Self::Subpixel, Self::Subpixel, Self::Subpixel);
 
     /// Construct a pixel from the 4 channels a, b, c and d.
     /// If the pixel does not contain 4 channels the extra are ignored.
+    ///
     /// TODO deprecate
     fn from_channels(a: Self::Subpixel, b: Self::Subpixel, c: Self::Subpixel, d: Self::Subpixel) -> Self;
 
@@ -75,13 +77,13 @@ pub trait Pixel: Copy + Clone {
     /// Apply the function ```f``` to each channel of this pixel.
     fn apply<F>(&mut self, f: F) where F: Fn(Self::Subpixel) -> Self::Subpixel;
 
-    /// Apply the function f to each channel except the alpha channel.
-    /// Apply the function g to the alpha channel.
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    /// Apply the function ```g``` to the alpha channel.
     fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
         where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
 
-    /// Apply the function f to each channel except the alpha channel.
-    /// Apply the function g to the alpha channel. Works in-place.
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    /// Apply the function ```g``` to the alpha channel. Works in-place.
     fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
         where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
 
@@ -221,6 +223,7 @@ where P: Pixel + 'static,
 
     /// Contructs a buffer from a generic container
     /// (for example a `Vec` or a slice)
+    ///
     /// Returns None if the container is not big enough
     pub fn from_raw(width: u32, height: u32, buf: Container)
                     -> Option<ImageBuffer<P, Container>> {
@@ -338,7 +341,7 @@ where P: Pixel + 'static,
     ///
     /// # Panics
     ///
-    /// Panics if `(x, y)` is out of the bounds (width, height)`.
+    /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     pub fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
     }
@@ -444,6 +447,7 @@ where P: Pixel + 'static,
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
+    ///
     /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
     fn blend_pixel(&mut self, x: u32, y: u32, p: P) {
         self.get_pixel_mut(x, y).blend(&p)

--- a/src/color.rs
+++ b/src/color.rs
@@ -24,7 +24,7 @@ pub enum ColorType {
     RGBA(u8)
 }
 
-/// Returns the number of bits contained in a pixel of ColorType c
+/// Returns the number of bits contained in a pixel of ColorType ```c```
 pub fn bits_per_pixel(c: ColorType) -> usize {
     match c {
         ColorType::Gray(n)    => n as usize,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -289,10 +289,11 @@ impl DynamicImage {
         dynamic_map!(*self, ref p => imageops::blur(p, sigma))
     }
 
-    /// Performs an unsharpen mask on this image
+    /// Performs an unsharpen mask on this image.
     /// ```sigma``` is the amount to blur the image by.
     /// ```threshold``` is a control of how much to sharpen.
-    /// see https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
+    ///
+    /// See https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
     pub fn unsharpen(&self, sigma: f32, threshold: i32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::unsharpen(p, sigma, threshold))
     }
@@ -609,6 +610,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 9] = [
 ];
 
 /// Create a new image from a byte slice
+///
 /// Makes an educated guess about the image format.
 /// TGA is not supported by this function.
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,7 +13,7 @@ use buffer::{ImageBuffer, Pixel};
 use animation::{Frame, Frames};
 use dynimage::decoder_to_image;
 
-/// An enumeration of Image Errors
+/// An enumeration of Image errors
 #[derive(Debug)]
 pub enum ImageError {
     /// The Image is not formatted properly
@@ -150,13 +150,13 @@ pub trait ImageDecoder: Sized {
     /// Returns a tuple containing the width and height of the image
     fn dimensions(&mut self) -> ImageResult<(u32, u32)>;
 
-    /// Returns the color type of the image e.g RGB(8) (8bit RGB)
+    /// Returns the color type of the image e.g. RGB(8) (8bit RGB)
     fn colortype(&mut self) -> ImageResult<ColorType>;
 
     /// Returns the length in bytes of one decoded row of the image
     fn row_len(&mut self) -> ImageResult<usize>;
 
-    /// Reads one row from the image into buf and returns the row index
+    /// Reads one row from the image into ```buf``` and returns the row index
     fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32>;
 
     /// Decodes the entire image and return it as a Vector
@@ -170,6 +170,7 @@ pub trait ImageDecoder: Sized {
     }
 
     /// Returns the frames of the image
+    ///
     /// If the image is not animated it returns a single frame
     fn into_frames(self) -> ImageResult<Frames> {
         Ok(Frames::new(vec![
@@ -252,6 +253,7 @@ impl<'a, I: GenericImage> Iterator for Pixels<'a, I> {
 }
 
 /// Mutable pixel iterator
+///
 /// DEPRECATED: It is currently not possible to create a safe iterator for this in Rust. You have to use an iterator over the image buffer instead.
 pub struct MutPixels<'a, I: 'a> {
     image:  &'a mut I,
@@ -333,6 +335,7 @@ pub trait GenericImage: Sized {
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
+    ///
     /// TODO: change this signature to &P
     fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel;
 
@@ -365,6 +368,7 @@ pub trait GenericImage: Sized {
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
+    ///
     /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
 
@@ -386,7 +390,8 @@ pub trait GenericImage: Sized {
     /// Returns an Iterator over mutable pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with a mutable reference to them.
-    /// DEPRECATED: "This cannot be implemented safely Rust. Please use the image buffer directly.
+    ///
+    /// DEPRECATED: This cannot be implemented safely in Rust. Please use the image buffer directly.
     fn pixels_mut(&mut self) -> MutPixels<Self> {
         let (width, height) = self.dimensions();
 

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -30,7 +30,7 @@ pub fn grayscale<'a, I: GenericImage>(image: &I)
     out
 }
 
-/// Invert each pixel within the supplied image
+/// Invert each pixel within the supplied image.
 /// This function operates in place.
 pub fn invert<I: GenericImage>(image: &mut I) {
     let (width, height) = image.dimensions();
@@ -45,7 +45,7 @@ pub fn invert<I: GenericImage>(image: &mut I) {
     }
 }
 
-/// Adjust the contrast of the supplied image
+/// Adjust the contrast of the supplied image.
 /// ```contrast``` is the amount to adjust the contrast by.
 /// Negative values decrease the contrast and positive values increase the contrast.
 pub fn contrast<I, P, S>(image: &I, contrast: f32)
@@ -80,7 +80,7 @@ pub fn contrast<I, P, S>(image: &I, contrast: f32)
     out
 }
 
-/// Brighten the supplied image
+/// Brighten the supplied image.
 /// ```value``` is the amount to brighten each pixel by.
 /// Negative values decrease the brightness and positive values increase it.
 pub fn brighten<I, P, S>(image: &I, value: i32)
@@ -118,7 +118,7 @@ pub trait ColorMap {
     /// Returns the index of the closed match of `color`
     /// in the color map.
     fn index_of(&self, color: &Self::Color) -> usize;
-    /// Maps `color` to the closes color in the color map.
+    /// Maps `color` to the closest color in the color map.
     fn map_color(&self, color: &mut Self::Color);
 }
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -360,7 +360,7 @@ pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32])
     out
 }
 
-/// Resize the supplied image to the specified dimensions
+/// Resize the supplied image to the specified dimensions.
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
@@ -424,10 +424,11 @@ pub fn blur<I: GenericImage + 'static>(image: &I, sigma: f32)
     horizontal_sample(&tmp, width, &mut method)
 }
 
-/// Performs an unsharpen mask on the supplied image
+/// Performs an unsharpen mask on the supplied image.
 /// ```sigma``` is the amount to blur the image by.
 /// ```threshold``` is the threshold for the difference between
-/// see https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
+///
+/// See https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32)
     -> ImageBuffer<P, Vec<S>>

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -176,6 +176,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
     /// Encodes the image ```image```
     /// that has dimensions ```width``` and ```height```
     /// and ```ColorType``` ```c```
+    ///
     /// The Image in encoded with subsampling ratio 4:2:2
     pub fn encode(&mut self,
                   image: &[u8],

--- a/src/tiff/decoder.rs
+++ b/src/tiff/decoder.rs
@@ -69,7 +69,7 @@ enum Predictor {
 }
 }
 
-/// The representation of a PNG decoder
+/// The representation of a TIFF decoder
 ///
 /// Currently does not support decoding of interlaced images
 #[derive(Debug)]
@@ -268,12 +268,12 @@ impl<R: Read + Seek> TIFFDecoder<R> {
     }
 
     /// Reads a IFD entry.
-    ///
-    /// And IFD entry has four fields
-    /// Tag   2 bytes
-    /// Type  2 bytes
-    /// Count 4 bytes
-    /// Value 4 bytes either a pointer the value itself
+    // An IFD entry has four fields:
+    //
+    // Tag   2 bytes
+    // Type  2 bytes
+    // Count 4 bytes
+    // Value 4 bytes either a pointer the value itself
     fn read_entry(&mut self) -> ImageResult<Option<(ifd::Tag, ifd::Entry)>> {
         let tag = ifd::Tag::from_u16(try!(self.read_short()));
         let type_: ifd::Type = match FromPrimitive::from_u16(try!(self.read_short())) {
@@ -332,7 +332,7 @@ impl<R: Read + Seek> TIFFDecoder<R> {
         }
     }
 
-    /// Tries to retrieve a tag an convert it to the desired type.
+    /// Tries to retrieve a tag and convert it to the desired type.
     fn find_tag_u32(&mut self, tag: ifd::Tag) -> ImageResult<Option<u32>> {
         match try!(self.find_tag(tag)) {
             Some(val) => Ok(Some(try!(val.as_u32()))),
@@ -340,7 +340,7 @@ impl<R: Read + Seek> TIFFDecoder<R> {
         }
     }
 
-    /// Tries to retrieve a tag an convert it to the desired type.
+    /// Tries to retrieve a tag and convert it to the desired type.
     fn find_tag_u32_vec(&mut self, tag: ifd::Tag) -> ImageResult<Option<Vec<u32>>> {
         match try!(self.find_tag(tag)) {
             Some(val) => Ok(Some(try!(val.as_u32_vec()))),
@@ -359,12 +359,12 @@ impl<R: Read + Seek> TIFFDecoder<R> {
         }
     }
 
-    /// Tries to retrieve a tag an convert it to the desired type.
+    /// Tries to retrieve a tag and convert it to the desired type.
     fn get_tag_u32(&mut self, tag: ifd::Tag) -> ImageResult<u32> {
         (try!(self.get_tag(tag))).as_u32()
     }
 
-    /// Tries to retrieve a tag an convert it to the desired type.
+    /// Tries to retrieve a tag and convert it to the desired type.
     fn get_tag_u32_vec(&mut self, tag: ifd::Tag) -> ImageResult<Vec<u32>> {
         (try!(self.get_tag(tag))).as_u32_vec()
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,11 +1,11 @@
-//! This module provides usefull traits that where deprecated in rust
+//! This module provides useful traits that were deprecated in rust
 
 // Note copied from the stdlib under MIT license
 
 use num::{ Bounded, Num, NumCast };
 
 
-/// Primitive trait from old stdlib, added max_value
+/// Primitive trait from old stdlib
 pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded {
 }
 

--- a/src/utils/lzw.rs
+++ b/src/utils/lzw.rs
@@ -19,7 +19,9 @@ const MAX_ENTRIES: usize = 1 << MAX_CODESIZE as usize;
 type Code = u16;
 
 /// Decoding dictionary
+///
 /// It is not generic due to current limitations of Rust
+///
 /// Inspired by http://www.cplusplus.com/articles/iL18T05o/
 struct DecodingDict {
     min_size: u8,

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -798,6 +798,7 @@ struct Segment {
 }
 
 /// VP8 Decoder
+///
 /// Only decodes keyframes
 pub struct VP8Decoder<R> {
     r: R,


### PR DESCRIPTION
Some doc comments were formatted like this:

    /// This is a sentence
    /// This is another sentence

When rendered to HTML, the above produces this:

> This is a sentence This is another sentence

I fixed these problems either by adding a blank line in between sentences or by adding a period.