### PR TITLE
use vec! macro for ImageBuffer::new

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,6 @@
 use std::slice::{ Chunks, ChunksMut };
 use std::ops::{ Deref, DerefMut, Index, IndexMut };
 use std::marker::PhantomData;
-use std::iter::repeat;
 use std::path::Path;
 use std::io;
 use num::Zero;
@@ -466,12 +465,11 @@ where P::Subpixel: 'static {
     /// Creates a new image buffer based on a `Vec<P::Subpixel>`.
     pub fn new(width: u32, height: u32) -> ImageBuffer<P, Vec<P::Subpixel>> {
         ImageBuffer {
-            data: repeat(Zero::zero()).take(
-                    (width as u64
-                     * height as u64
-                     * (<P as Pixel>::channel_count() as u64)
-                    ) as usize
-                ).collect(),
+            data: vec![Zero::zero(); 
+                      (width as u64
+                      * height as u64
+                      * (<P as Pixel>::channel_count() as u64)
+                      ) as usize],
             width: width,
             height: height,
             _phantom: PhantomData,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::mem;
 use std::io;
-use std::iter::repeat;
 use std::error::Error;
 
 use byteorder;
@@ -193,8 +192,8 @@ pub trait ImageDecoder: Sized {
 
         let rowlen  = try!(self.row_len());
 
-        let mut buf = repeat(0u8).take(length as usize * width as usize * bpp).collect::<Vec<u8>>();
-        let mut tmp = repeat(0u8).take(rowlen).collect::<Vec<u8>>();
+        let mut buf = vec![0u8; length as usize * width as usize * bpp];
+        let mut tmp = vec![0u8; rowlen];
 
         loop {
             let row = try!(self.read_scanline(&mut tmp));

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -1,4 +1,3 @@
-use std::iter::repeat;
 use std::io::Read;
 use byteorder::ReadBytesExt;
 
@@ -109,8 +108,8 @@ impl HuffDecoder {
 /// this function generates the huffman codes lengths and their respective
 /// code lengths as specified by the JPEG spec.
 fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
-    let mut huffsize = repeat(0u8).take(256).collect::<Vec<u8>>();
-    let mut huffcode = repeat(0u16).take(256).collect::<Vec<u16>>();
+    let mut huffsize = vec![0u8; 256];
+    let mut huffcode = vec![0u16; 256];
 
     let mut k = 0;
     let mut j;
@@ -157,7 +156,7 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
 }
 
 pub fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
-    let mut lut = repeat((17u8, 0u16)).take(256).collect::<Vec<(u8, u16)>>();
+    let mut lut = vec![(17u8, 0u16); 256];
     let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 
     for (i, &v) in huffval.iter().enumerate() {
@@ -168,10 +167,10 @@ pub fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
 }
 
 pub fn derive_tables(bits: Vec<u8>, huffval: Vec<u8>) -> HuffTable {
-    let mut mincode = repeat(-1isize).take(16).collect::<Vec<isize>>();
-    let mut maxcode = repeat(-1isize).take(16).collect::<Vec<isize>>();
-    let mut valptr  = repeat(-1isize).take(16).collect::<Vec<isize>>();
-    let mut lut     = repeat((0u8, 17u8)).take(256).collect::<Vec<(u8, u8)>>();
+    let mut mincode = vec![-1isize; 16];
+    let mut maxcode = vec![-1isize; 16];
+    let mut valptr  = vec![-1isize; 16];
+    let mut lut     = vec![(0u8, 17u8); 256];
 
     let (huffsize, huffcode) = derive_codes_and_sizes(&bits);
 

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -15,7 +15,6 @@
 use std::io;
 use std::io::Read;
 use std::default::Default;
-use std::iter::repeat;
 use byteorder::{ReadBytesExt, LittleEndian};
 
 use super::transform;
@@ -1052,11 +1051,11 @@ impl<R: Read> VP8Decoder<R> {
             self.mbwidth  = (self.frame.width + 15) / 16;
             self.mbheight = (self.frame.height + 15) / 16;
 
-            self.frame.ybuf = repeat(0u8).take(self.frame.width as usize
-                * self.frame.height as usize).collect();
+            self.frame.ybuf = vec![0u8; self.frame.width as usize * 
+                                        self.frame.height as usize];
 
-            self.top_border = repeat(127u8).take(self.frame.width as usize + 4 + 16).collect();
-            self.left_border = repeat(129u8).take(1 + 16).collect();
+            self.top_border = vec![127u8; self.frame.width as usize + 4 + 16];
+            self.left_border = vec![129u8; 1 + 16];
         }
 
         let mut buf = Vec::with_capacity(first_partition_size as usize);
@@ -1420,7 +1419,7 @@ impl<R: Read> VP8Decoder<R> {
                 self.intra_predict(mbx, mby, &mb, &blocks);
             }
 
-            self.left_border = repeat(129u8).take(1 + 16).collect();
+            self.left_border = vec![129u8; 1 + 16];
         }
 
         Ok(&self.frame)


### PR DESCRIPTION
Change ImageBuffer default constructor (for Vec container) to use vec! macro.
```
before:
test buffer::test::bench_conversion        ... bench:   7,130,486 ns/iter (+/- 106,108) = 420 MB/s
test dynimage::bench::bench_conversion     ... bench:   7,123,419 ns/iter (+/- 34,759) = 420 MB/s
test imageops::sample::tests::bench_resize ... bench:   8,605,023 ns/iter (+/- 50,953) = 236 MB/s

after:
test buffer::test::bench_conversion        ... bench:   5,204,968 ns/iter (+/- 25,449) = 576 MB/s
test dynimage::bench::bench_conversion     ... bench:   5,204,117 ns/iter (+/- 20,338) = 576 MB/s
test imageops::sample::tests::bench_resize ... bench:   7,673,833 ns/iter (+/- 99,008) = 265 MB/s
```

Changes impact impageproc too:
```before
test affine::test::bench_rotate_bilinear                              ... bench:     723,508 ns/iter (+/- 43,365)
test affine::test::bench_rotate_nearest                               ... bench:     417,903 ns/iter (+/- 20,282)
test affine::test::bench_translate                                    ... bench:     938,693 ns/iter (+/- 6,434)
test contrast::test::bench_equalize_histogram                         ... bench:   3,933,365 ns/iter (+/- 27,685)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          27 ns/iter (+/- 0)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          29 ns/iter (+/- 0)
test filter::test::bench_box_filter                                   ... bench:   4,973,883 ns/iter (+/- 62,633)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   3,381,504 ns/iter (+/- 21,686)
test filter::test::bench_horizontal_filter                            ... bench:   9,714,388 ns/iter (+/- 30,177)
test filter::test::bench_separable_filter                             ... bench:   6,983,245 ns/iter (+/- 26,106)
test filter::test::bench_vertical_filter                              ... bench:   9,856,291 ns/iter (+/- 48,827)
test integralimage::test::bench_column_running_sum                    ... bench:       3,698 ns/iter (+/- 51)
test integralimage::test::bench_integral_image                        ... bench:   1,608,849 ns/iter (+/- 10,780)
test integralimage::test::bench_row_running_sum                       ... bench:       3,483 ns/iter (+/- 17)
test suppress::test::bench_local_maxima_dense                         ... bench:      42,237 ns/iter (+/- 9,673)
test suppress::test::bench_local_maxima_sparse                        ... bench:      44,919 ns/iter (+/- 330)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     209,578 ns/iter (+/- 1,372)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     229,177 ns/iter (+/- 1,350)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:     258,725 ns/iter (+/- 1,678)

after
test affine::test::bench_rotate_bilinear                              ... bench:     665,395 ns/iter (+/- 7,632)
test affine::test::bench_rotate_nearest                               ... bench:     356,090 ns/iter (+/- 4,673)
test affine::test::bench_translate                                    ... bench:     507,069 ns/iter (+/- 3,498)
test contrast::test::bench_equalize_histogram                         ... bench:   3,520,825 ns/iter (+/- 45,802)
test corners::test::bench_is_corner_fast12_12_noncontiguous           ... bench:          27 ns/iter (+/- 1)
test corners::test::bench_is_corner_fast9_9_contiguous_lighter_pixels ... bench:          29 ns/iter (+/- 0)
test filter::test::bench_box_filter                                   ... bench:   4,603,757 ns/iter (+/- 311,278)
test filter::test::bench_filter3x3_i32_filter                         ... bench:   2,564,050 ns/iter (+/- 112,980)
test filter::test::bench_horizontal_filter                            ... bench:   9,290,717 ns/iter (+/- 142,560)
test filter::test::bench_separable_filter                             ... bench:   6,668,658 ns/iter (+/- 180,966)
test filter::test::bench_vertical_filter                              ... bench:   9,458,380 ns/iter (+/- 183,229)
test integralimage::test::bench_column_running_sum                    ... bench:       3,820 ns/iter (+/- 142)
test integralimage::test::bench_integral_image                        ... bench:   1,452,976 ns/iter (+/- 78,702)
test integralimage::test::bench_row_running_sum                       ... bench:       3,485 ns/iter (+/- 19)
test suppress::test::bench_local_maxima_dense                         ... bench:      38,114 ns/iter (+/- 426)
test suppress::test::bench_local_maxima_sparse                        ... bench:      45,574 ns/iter (+/- 546)
test suppress::test::bench_suppress_non_maximum_decreasing_gradient   ... bench:     211,604 ns/iter (+/- 2,357)
test suppress::test::bench_suppress_non_maximum_increasing_gradient   ... bench:     231,685 ns/iter (+/- 3,345)
test suppress::test::bench_suppress_non_maximum_noise                 ... bench:     261,134 ns/iter (+/- 4,973)
```