### PR TITLE
inline unsafe_get_pixel and unsafe_put_pixel

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -442,6 +442,7 @@ where P: Pixel + 'static,
     }
     
     /// Returns the pixel located at (x, y), ignoring bounds checking.
+    #[inline(always)]
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> P {
         let no_channels = <P as Pixel>::channel_count() as usize;
         let index  = no_channels as isize * (y * self.width + x) as isize;
@@ -456,6 +457,7 @@ where P: Pixel + 'static,
     }
     
     /// Puts a pixel at location (x, y), ignoring bounds checking.
+    #[inline(always)]
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         let no_channels = <P as Pixel>::channel_count() as usize;
         let index  = no_channels as isize * (y * self.width + x) as isize;


### PR DESCRIPTION
As [suggested by @bvssvni](https://github.com/PistonDevelopers/image/commit/64d94e54491db2e1cdc6c53f77d544540296a3d2#commitcomment-15292443)

imageproc 
```
before
test affine::test::bench_translate                                    ... bench:   1,120,290 ns/iter (+/- 25,158)

after
test affine::test::bench_translate                                    ... bench:     298,141 ns/iter (+/- 5,832)
```