### PR TITLE
Make de-generics wrappers for open and save_buffer

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -515,8 +515,11 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
 /// Open the image located at the path specified.
 /// The image's format is determined from the path's file extension.
 pub fn open<P>(path: P) -> ImageResult<DynamicImage> where P: AsRef<Path> {
-    let path = path.as_ref();
+    // thin wrapper function to strip generics before calling open_impl
+    open_impl(path.as_ref())
+}
 
+fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
     let fin = match File::open(path) {
         Ok(f)  => f,
         Err(err) => return Err(image::ImageError::IoError(err))
@@ -554,7 +557,12 @@ pub fn open<P>(path: P) -> ImageResult<DynamicImage> where P: AsRef<Path> {
 /// jpeg and png files are supported.
 pub fn save_buffer<P>(path: P, buf: &[u8], width: u32, height: u32, color: color::ColorType)
                       -> io::Result<()> where P: AsRef<Path> {
-    let path = path.as_ref();
+    // thin wrapper function to strip generics before calling save_buffer_impl
+    save_buffer_impl(path.as_ref(), buf, width, height, color)
+}
+
+fn save_buffer_impl(path: &Path, buf: &[u8], width: u32, height: u32, color: color::ColorType)
+                      -> io::Result<()> {
     let ref mut fout = try!(File::create(path));
     let ext = path.extension().and_then(|s| s.to_str())
                   .map_or("".to_string(), |s| s.to_ascii_lowercase());


### PR DESCRIPTION
This makes the inner parts of these functions non-inlinable. It also
makes open_impl and save_buffer_impl be compiled once, as part of
compiling the crate, instead of having to compile them each time their
*uses* are compiled.

This was prompted by http://stackoverflow.com/questions/36317461/

Modifying the user library and recompiling took more than 20 seconds,
with this change, only < 0.3 s. This means that `open`'s implementation
may no longer be inlined, but it shouldn't matter.