### PR TITLE
Removed use of deprecated function. Replaced with std::io::Write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ extern crate enum_primitive;
 #[cfg(test)]
 extern crate test;
 
+use std::io::Write;
+
 pub use color::ColorType::{
     self,
     Gray,
@@ -134,16 +136,9 @@ mod animation;
 // Copies data from `src` to `dst`
 //
 // Panics if the length of `dst` is less than the length of `src`.
-// NOTE: this is a copy-paste of the unstable function `std::slice::bytes::copy_memory`.
 #[inline]
-fn copy_memory(src: &[u8], dst: &mut [u8]) {
+fn copy_memory(src: &[u8], mut dst: &mut [u8]) {
     let len_src = src.len();
     assert!(dst.len() >= len_src);
-    // `dst` is unaliasable, so we know statically it doesn't overlap
-    // with `src`.
-    unsafe {
-        std::ptr::copy_nonoverlapping(src.as_ptr(),
-                                      dst.as_mut_ptr(),
-                                      len_src);
-    }
+    dst.write(src).unwrap();
 }


### PR DESCRIPTION
Really minor update. Had no impact on performance when last tested, but I figured it's always better to keep current with Rust.