### PR TITLE
Update to png 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.9.0"
+version = "0.9.1"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [
@@ -38,7 +38,7 @@ version = "0.1"
 optional = true
 
 [dependencies.png]
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
I believe this can be a minor change because image does not expose any types from png in its public API.