### PR TITLE
Add support for encoding ICO files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ http://www.piston.rs/image/image/index.html
 | JPEG   | Baseline and progressive | Baseline JPEG |
 | GIF    | Yes | Yes |
 | BMP    | Yes | No |
-| ICO    | Yes | No |
+| ICO    | Yes | Yes |
 | TIFF   | Baseline(no fax and packbits support) + LZW | No |
 | Webp   | Lossy(Luma channel only) | No |
 | PPM    | No | Yes |

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -388,6 +388,14 @@ impl DynamicImage {
                 Ok(())
             }
 
+            #[cfg(feature = "ico")]
+            image::ImageFormat::ICO => {
+                let i = ico::ICOEncoder::new(w);
+
+                try!(i.encode(&bytes, width, height, color));
+                Ok(())
+            }
+
             _ => Err(image::ImageError::UnsupportedError(
                      format!("An encoder for {:?} is not available.", format))
                  ),
@@ -568,6 +576,8 @@ fn save_buffer_impl(path: &Path, buf: &[u8], width: u32, height: u32, color: col
                   .map_or("".to_string(), |s| s.to_ascii_lowercase());
 
     match &*ext {
+        #[cfg(feature = "ico")]
+        "ico" => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "jpeg")]
         "jpg" |
         "jpeg" => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -1,0 +1,85 @@
+use byteorder::{WriteBytesExt, LittleEndian};
+use std::io::{self, Write};
+
+use color::{ColorType, bits_per_pixel};
+
+use png::PNGEncoder;
+
+// Enum value indicating an ICO image (as opposed to a CUR image):
+const ICO_IMAGE_TYPE: u16 = 1;
+// The length of an ICO file ICONDIR structure, in bytes:
+const ICO_ICONDIR_SIZE: u32 = 6;
+// The length of an ICO file DIRENTRY structure, in bytes:
+const ICO_DIRENTRY_SIZE: u32 = 16;
+
+/// ICO encoder
+pub struct ICOEncoder<W: Write> {
+    w: W
+}
+
+impl<W: Write> ICOEncoder<W> {
+    /// Create a new encoder that writes its output to ```w```.
+    pub fn new(w: W) -> ICOEncoder<W> {
+        ICOEncoder {
+            w: w
+        }
+    }
+
+    /// Encodes the image ```image``` that has dimensions ```width``` and
+    /// ```height``` and ```ColorType``` ```c```.  The dimensions of the image
+    /// must be between 1 and 256 (inclusive) or an error will be returned.
+    pub fn encode(mut self, data: &[u8], width: u32, height: u32,
+                  color: ColorType) -> io::Result<()> {
+        let mut image_data: Vec<u8> = Vec::new();
+        try!(PNGEncoder::new(&mut image_data).encode(
+            data, width, height, color));
+
+        try!(write_icondir(&mut self.w, 1));
+        try!(write_direntry(&mut self.w, width, height, color,
+                            ICO_ICONDIR_SIZE + ICO_DIRENTRY_SIZE,
+                            image_data.len() as u32));
+        try!(self.w.write_all(&image_data));
+        Ok(())
+    }
+}
+
+fn write_icondir<W: Write>(w: &mut W, num_images: u16) -> io::Result<()> {
+    // Reserved field (must be zero):
+    try!(w.write_u16::<LittleEndian>(0));
+    // Image type (ICO or CUR):
+    try!(w.write_u16::<LittleEndian>(ICO_IMAGE_TYPE));
+    // Number of images in the file:
+    try!(w.write_u16::<LittleEndian>(num_images));
+    Ok(())
+}
+
+fn write_direntry<W: Write>(w: &mut W, width: u32, height: u32,
+                            color: ColorType, data_start: u32,
+                            data_size: u32) -> io::Result<()> {
+    // Image dimensions:
+    try!(write_width_or_height(w, width));
+    try!(write_width_or_height(w, height));
+    // Number of colors in palette (or zero for no palette):
+    try!(w.write_u8(0));
+    // Reserved field (must be zero):
+    try!(w.write_u8(0));
+    // Color planes:
+    try!(w.write_u16::<LittleEndian>(0));
+    // Bits per pixel:
+    try!(w.write_u16::<LittleEndian>(bits_per_pixel(color) as u16));
+    // Image data size, in bytes:
+    try!(w.write_u32::<LittleEndian>(data_size));
+    // Image data offset, in bytes:
+    try!(w.write_u32::<LittleEndian>(data_start));
+    Ok(())
+}
+
+/// Encode a width/height value as a single byte, where 0 means 256.
+fn write_width_or_height<W: Write>(w: &mut W, value: u32) -> io::Result<()> {
+    if value < 1 || value > 256 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData,
+                                  "Invalid ICO dimensions (width and \
+                                   height must be between 1 and 256)"));
+    }
+    w.write_u8(if value < 256 { value as u8 } else { 0 })
+}

--- a/src/ico/mod.rs
+++ b/src/ico/mod.rs
@@ -1,11 +1,13 @@
-//!  Decoding of ICO files
+//!  Decoding and Encoding of ICO files
 //!
-//!  A decoder for ICO (Windows Icon) image container files
+//!  A decoder and encoder for ICO (Windows Icon) image container files.
 //!
 //!  # Related Links
 //!  * https://msdn.microsoft.com/en-us/library/ms997538.aspx
 //!  * https://en.wikipedia.org/wiki/ICO_%28file_format%29
 
 pub use self::decoder::ICODecoder;
+pub use self::encoder::ICOEncoder;
 
 mod decoder;
+mod encoder;


### PR DESCRIPTION
This change adds an `ICOEncoder` struct, and uses it in `DynamicImage` to support encoding ICO files.  The implementation is very simple, since `PNGEncoder` does all the heavy lifting.

If desired, `ICOEncoder` could be expanded in the future to support storing multiple images in the same ICO file, but for now it just encodes a single image (with the same API as `PNGEncoder`).