### PR TITLE
bmp/decoder: ensure palette has correct length

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -449,7 +449,8 @@ impl<R: Read + Seek> BMPDecoder<R> {
         let max_length = MAX_PALETTE_SIZE * bytes_per_color;
         let mut buf = Vec::with_capacity(max_length);
 
-        try!(self.r.by_ref().take(length as u64).read_to_end(&mut buf));
+        buf.resize(length, 0);
+        try!(self.r.by_ref().read_exact(&mut buf));
 
         // Allocate 256 entries even if palette_size is smaller, to prevent corrupt files from
         // causing an out-of-bounds array access.

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -303,8 +303,8 @@ impl<R: Read + Seek> TGADecoder<R> {
             try!(self.read_encoded_data())
         } else {
             let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
-            let mut buf = Vec::with_capacity(num_raw_bytes);
-            try!(self.r.by_ref().take(num_raw_bytes as u64).read_to_end(&mut buf));
+            let mut buf = vec![0; num_raw_bytes];
+            try!(self.r.by_ref().read_exact(&mut buf));
             buf
         };
 

--- a/tests/truncate_images.rs
+++ b/tests/truncate_images.rs
@@ -1,0 +1,79 @@
+//! Ensure truncated images are read without panics.
+
+use std::fs;
+use std::path::PathBuf;
+use std::io::Read;
+
+extern crate image;
+extern crate glob;
+
+const BASE_PATH: [&'static str; 2] = [".", "tests"];
+const IMAGE_DIR: &'static str = "images";
+
+fn process_images<F>(dir: &str, input_decoder: Option<&str>, func: F)
+where F: Fn(PathBuf) {
+	let base: PathBuf = BASE_PATH.iter().collect();
+	let decoders = &["tga", "tiff", "png", "gif", "bmp", "ico", "jpg"];
+	for decoder in decoders {
+		let mut path = base.clone();
+		path.push(dir);
+		path.push(decoder);
+		path.push("*");
+		path.push("*.".to_string() + match input_decoder {
+			Some(val) => val,
+			None => decoder
+		});
+		let pattern = &*format!("{}", path.display());
+		for path in glob::glob(pattern).unwrap().filter_map(Result::ok) {
+			func(path)
+		}
+	}
+}
+
+fn truncate_images(decoder: &str) {
+    process_images(IMAGE_DIR, Some(decoder), |path| {
+        println!("{:?}", path);
+        let fin = fs::File::open(&path).unwrap();
+        let max_length = 1000;
+        let mut buf = Vec::with_capacity(max_length);
+        fin.take(max_length as u64).read_to_end(&mut buf).unwrap();
+        for i in 0..buf.len() {
+            image::load_from_memory(&buf[..i+1]).ok();
+        }
+    })
+}
+
+#[test] #[ignore]
+fn truncate_tga() {
+    truncate_images("tga")
+}
+
+#[test] #[ignore]
+fn truncate_tiff() {
+    truncate_images("tiff")
+}
+
+#[test] #[ignore]
+fn truncate_png() {
+    truncate_images("png")
+}
+
+#[test] #[ignore]
+fn truncate_gif() {
+    truncate_images("gif")
+}
+
+#[test] #[ignore]
+fn truncate_bmp() {
+    truncate_images("bmp")
+}
+
+#[test] #[ignore]
+fn truncate_ico() {
+    truncate_images("ico")
+}
+
+#[test] #[ignore]
+fn truncate_jpg() {
+    truncate_images("jpg")
+}


### PR DESCRIPTION
This is a minimal fix for #477.

I'm not sure this is the best fix though. What's the general philosophy regarding corrupt files? Should we fail if we detect corruption, or proceed as best as possible? A related concern is whether there should there be a limit on image width, height, palette size etc; we don't want to use gigabytes of memory due to a corrupt or malicious file.

Should I convert the test case into a file and add it under tests? This would be different from the existing tests, because I don't think there are any test cases for invalid files yet.

I also plan to audit other uses of read_to_end().