### PR TITLE
Make decoding result enum public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub use image::{
     ImageDecoder,
     ImageError,
     ImageResult,
+    DecodingResult,
     SubImage,
     GenericImage,
     // Iterators


### PR DESCRIPTION
I was trying to compile a simple example using a jpeg decoder and noticed the `DecodingResult` enum is not public.

Example code I mentioned above: https://github.com/srdqty/rust-practice/blob/57cbc9e72d2429d6600c7adbdfc73bc6d027e1b5/image-hello-world/src/main.rs