### PR TITLE
Fix build failure when HDR feature is disabled

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -632,7 +632,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 10] = [
     (b"II*.", ImageFormat::TIFF),
     (b"BM", ImageFormat::BMP),
     (&[0, 0, 1, 0], ImageFormat::ICO),
-    (hdr::SIGNATURE, ImageFormat::HDR),
+    (b"#?RADIANCE", ImageFormat::HDR),
 ];
 
 /// Create a new image from a byte slice


### PR DESCRIPTION
Currently, access to the `hdr` module is attempted when building the array of magic bytes even when the feature is disabled. This change inserts the bytes directly without accessing the module.