### PR TITLE
Add Format from Memory

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -658,6 +658,22 @@ pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageRes
     load(b, format)
 }
 
+/// Guess image format from memory block
+///
+/// Makes an educated guess about the image format based on the Magic Bytes at the beginning.
+/// TGA is not supported by this function.
+/// This is not to be trusted on the validity of the whole memory block
+pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
+    for &(signature, format) in MAGIC_BYTES.iter() {
+        if buffer.starts_with(signature) {
+            return Ok(format);
+        }
+    }
+    Err(image::ImageError::UnsupportedError(
+        "Unsupported image format".to_string())
+    )
+}
+
 #[cfg(test)]
 mod bench {
     use test;

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -640,14 +640,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 10] = [
 /// Makes an educated guess about the image format.
 /// TGA is not supported by this function.
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
-    for &(signature, format) in MAGIC_BYTES.iter() {
-        if buffer.starts_with(signature) {
-            return load_from_memory_with_format(buffer, format)
-        }
-    }
-    Err(image::ImageError::UnsupportedError(
-        "Unsupported image format".to_string())
-    )
+    load_from_memory_with_format(buffer, try!(guess_format(buffer)))
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub use dynimage::{
     load,
     load_from_memory,
     load_from_memory_with_format,
+    guess_format,
     save_buffer
 };
 


### PR DESCRIPTION
I was missing this functionality as I would like to keep the original format from a file on files uploaded by users.