### PR TITLE
move benchmarking to a 'benchmarks' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,5 @@ tiff = []
 webp = []
 bmp = []
 hdr = ["scoped_threadpool"]
+
+benchmarks = []

--- a/benches/load.rs
+++ b/benches/load.rs
@@ -1,3 +1,4 @@
+#[cfg(benchmarks)]
 #![feature(test)]
 
 extern crate image;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -614,6 +614,7 @@ mod test {
 
     use super::{ImageBuffer, RgbImage, GrayImage, ConvertBuffer, Pixel};
     use color;
+    #[cfg(benchmarks)]
     use test;
 
     #[test]
@@ -646,6 +647,7 @@ mod test {
     }
 
     #[bench]
+    #[cfg(benchmarks)]
     fn bench_conversion(b: &mut test::Bencher) {
         let mut a: RgbImage = ImageBuffer::new(1000, 1000);
         for mut p in a.pixels_mut() {

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -669,9 +669,11 @@ pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
 
 #[cfg(test)]
 mod bench {
+    #[cfg(benchmarks)]
     use test;
 
     #[bench]
+    #[cfg(benchmarks)]
     fn bench_conversion(b: &mut test::Bencher) {
         let a = super::DynamicImage::ImageRgb8(::ImageBuffer::new(1000, 1000));
         b.iter(|| {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -468,13 +468,14 @@ pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32)
 
 #[cfg(test)]
 mod tests {
+    #[cfg(benchmarks)]
     use test;
     use buffer::{ImageBuffer, RgbImage};
     use super::{resize, FilterType};
     use std::path::Path;
 
     #[bench]
-    #[cfg(feature = "png_codec")]
+    #[cfg(all(benchmarks, feature = "png_codec"))]
     fn bench_resize(b: &mut test::Bencher) {
         let img = ::open(&Path::new("./examples/fractal.png")).unwrap();
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(missing_copy_implementations)]
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(all(test, benchmarks), feature(test))]
 
 extern crate byteorder;
 extern crate num_iter;
@@ -13,7 +13,7 @@ extern crate num_rational;
 extern crate num_traits;
 #[macro_use]
 extern crate enum_primitive;
-#[cfg(test)]
+#[cfg(all(test, benchmarks))]
 extern crate test;
 
 use std::io::Write;


### PR DESCRIPTION
I tried out moving all of the testing code for benchmarking, which uses unstable features out into it's own feature.  This should allow the rest of the tests to run on stable and beta, and then the specialized tests can still be run on nightly.