### PR TITLE
Expose quality/compression when saving JPEGs

### DIFF
--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -1,0 +1,24 @@
+//! Example showing JPEG compression.
+extern crate image;
+
+use std::env;
+use std::fs::File;
+use std::path::Path;
+
+use image::GenericImage;
+
+fn main() {
+    let file = env::args().nth(1).expect("Please enter a file");
+    let qual = env::args().nth(2).expect("Please enter a quality");
+    let qual: u8 = qual.parse().expect(&format!("Invalid quality: {}", qual));
+
+    // Use the open function to load an image from a Path.
+    // ```open``` returns a dynamic image.
+    let im = image::open(&Path::new(&file)).unwrap();
+
+    // Create a new JPEG file with the same file name.
+    let ref mut fout = File::create(format!("{}.jpg", file)).unwrap();
+
+    // Write the image contents to the Writer in a compressed JPEG format.
+    let _ = im.save_jpeg_with_quality(fout, qual).unwrap();
+}

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs::File;
 use std::path::Path;
 
-use image::GenericImage;
+use image::{CompressedImageFormat, GenericImage};
 
 fn main() {
     let file = env::args().nth(1).expect("Please enter a file");
@@ -20,5 +20,5 @@ fn main() {
     let ref mut fout = File::create(format!("{}.jpg", file)).unwrap();
 
     // Write the image contents to the Writer in a compressed JPEG format.
-    let _ = im.save_jpeg_with_quality(fout, qual).unwrap();
+    im.save_compressed(fout, CompressedImageFormat::JPEG(qual)).unwrap();
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -32,6 +32,7 @@ use buffer::{ImageBuffer, ConvertBuffer, Pixel, GrayImage, GrayAlphaImage, RgbIm
 use imageops;
 use image;
 use image:: {
+    CompressedImageFormat,
     GenericImage,
     ImageDecoder,
     ImageResult,
@@ -405,17 +406,21 @@ impl DynamicImage {
         }
     }
 
-    /// Encode this image as JPEG with specified quality and write it to ```w```
-    #[cfg(feature = "jpeg")]
-    pub fn save_jpeg_with_quality<W: Write>(&self, w: &mut W, quality: u8) -> ImageResult<()> {
+    /// Encode/compress this image and write it to ```w```
+    pub fn save_compressed<W: Write>(&self, w: &mut W, format: CompressedImageFormat) -> ImageResult<()> {
         let bytes = self.raw_pixels();
         let (width, height) = self.dimensions();
         let color = self.color();
 
-        let mut j = jpeg::JPEGEncoder::new_with_quality(w, quality);
+        match format {
+            #[cfg(feature = "jpeg")]
+            CompressedImageFormat::JPEG(quality) => {
+                let mut j = jpeg::JPEGEncoder::new_with_quality(w, quality);
 
-        try!(j.encode(&bytes, width, height, color));
-        Ok(())
+                try!(j.encode(&bytes, width, height, color));
+                Ok(())
+            }
+        }
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -404,6 +404,19 @@ impl DynamicImage {
                  ),
         }
     }
+
+    /// Encode this image as JPEG with specified quality and write it to ```w```
+    #[cfg(feature = "jpeg")]
+    pub fn save_jpeg_with_quality<W: Write>(&self, w: &mut W, quality: u8) -> ImageResult<()> {
+        let bytes = self.raw_pixels();
+        let (width, height) = self.dimensions();
+        let color = self.color();
+
+        let mut j = jpeg::JPEGEncoder::new_with_quality(w, quality);
+
+        try!(j.encode(&bytes, width, height, color));
+        Ok(())
+    }
 }
 
 #[allow(deprecated)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -136,6 +136,13 @@ pub enum ImageFormat {
     HDR,
 }
 
+/// An enumeration of supported compressible image formats.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CompressedImageFormat {
+    /// An Image in JPEG Format with specified quality
+    JPEG(u8),
+}
+
 /// The trait that all decoders implement
 pub trait ImageDecoder: Sized {
     /// Returns a tuple containing the width and height of the image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use color::{
 };
 
 pub use image::{
+    CompressedImageFormat,
     ImageDecoder,
     ImageError,
     ImageResult,


### PR DESCRIPTION
This implements a `save_jpeg_with_quality` function for `DynamicImage`s, that takes a `Write` and a quality value. The function constructs a new `JPEGEncoder` with said quality (using the recently implemented `JPEGEncoder::new_with_quality`) and encodes it to the `Write` - simple stuff!

I also added an example showing compression. Closes #581.
