### PR TITLE
Add sepia to colorops

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ assert!(subimg.dimensions() == (100, 100));
 These are the functions defined in the ```imageops``` module. All functions operate on types that implement the ```GenericImage``` trait.
 
 + **blur**: Performs a Gaussian blur on the supplied image.
++ **sepia**: Sepia filter the supplied image by given amount
 + **brighten**: Brighten the supplied image
 + **contrast**: Adjust the contrast of the supplied image
 + **crop**: Return a mutable view into an image

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -317,6 +317,11 @@ impl DynamicImage {
         dynamic_map!(*self, ref p => imageops::contrast(p, c))
     }
 
+
+    pub fn sepia(&self, value: f64) -> DynamicImage {
+        dynamic_map!(*self, ref p => imageops::sepia(p, value))
+    }
+
     /// Brighten the pixels of this image.
     /// ```value``` is the amount to brighten each pixel by.
     /// Negative values decrease the brightness and positive values increase it.

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -316,8 +316,10 @@ impl DynamicImage {
     pub fn adjust_contrast(&self, c: f32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::contrast(p, c))
     }
-
-
+    
+    /// The sepia filter effect is a brownish-grey to dark yellowish-brown tone
+    /// imparted to an image and is expressed in percentages from 0.0 to 1.0
+    /// `value` is the amount/percentage e.g. sepia(1.0) just like the css filter sepia(100%)
     pub fn sepia(&self, value: f64) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::sepia(p, value))
     }

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -76,6 +76,51 @@ pub fn contrast<I, P, S>(image: &I, contrast: f32)
     out
 }
 
+/// The sepia filter effect is a brownish-grey to dark yellowish-brown tone
+/// imparted to an image and is expressed in percentages from 0.0 to 1.0
+/// `value` is the amount/percentage e.g. sepia(1.0) just like the css filter sepia(100%)
+/// https://developer.mozilla.org/de/docs/Web/CSS/filter
+pub fn sepia<I, P, S>(image: &I, value: f64)
+    -> ImageBuffer<P, Vec<S>>
+    where I: GenericImage<Pixel=P>,
+          P: Pixel<Subpixel=S> + 'static,
+          S: Primitive + 'static {
+
+    let (width, height) = image.dimensions();
+    let mut out = ImageBuffer::new(width, height);
+
+    // TODO: clamp to 0.0/1.0
+    let amount: f64 = 1.0f64 - value;
+
+    for (x, y, pixel) in out.enumerate_pixels_mut() {
+        let p = image.get_pixel(x, y);
+        let (k1, k2, k3, k4) = p.channels4();
+        let vec: (f64, f64, f64, f64) = (
+            NumCast::from(k1).unwrap(),
+            NumCast::from(k2).unwrap(),
+            NumCast::from(k3).unwrap(),
+            NumCast::from(k4).unwrap()
+        );
+
+        let r = vec.0;
+        let g = vec.1;
+        let b = vec.2;
+
+        let new_r = (0.393 + 0.607 * amount) * r + (0.769 - 0.769 * amount) * g + (0.189 - 0.189 * amount) * b;
+        let new_g = (0.349 - 0.349 * amount) * r + (0.686 + 0.314 * amount) * g + (0.168 - 0.168 * amount) * b;
+        let new_b = (0.272 - 0.272 * amount) * r + (0.534 - 0.534 * amount) * g + (0.131 + 0.869 * amount) * b;
+        let max = 255f64;
+        let outpixel = Pixel::from_channels(
+            NumCast::from(clamp(new_r, 0.0, max)).unwrap(),
+            NumCast::from(clamp(new_g, 0.0, max)).unwrap(),
+            NumCast::from(clamp(new_b, 0.0, max)).unwrap(),
+            NumCast::from(clamp(vec.3, 0.0, max)).unwrap()
+        );
+        *pixel = outpixel;
+    }
+    out
+}
+
 /// Brighten the supplied image.
 /// ```value``` is the amount to brighten each pixel by.
 /// Negative values decrease the brightness and positive values increase it.

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -79,7 +79,6 @@ pub fn contrast<I, P, S>(image: &I, contrast: f32)
 /// The sepia filter effect is a brownish-grey to dark yellowish-brown tone
 /// imparted to an image and is expressed in percentages from 0.0 to 1.0
 /// `value` is the amount/percentage e.g. sepia(1.0) just like the css filter sepia(100%)
-/// https://developer.mozilla.org/de/docs/Web/CSS/filter
 pub fn sepia<I, P, S>(image: &I, value: f64)
     -> ImageBuffer<P, Vec<S>>
     where I: GenericImage<Pixel=P>,
@@ -89,8 +88,7 @@ pub fn sepia<I, P, S>(image: &I, value: f64)
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
 
-    // TODO: clamp to 0.0/1.0
-    let amount: f64 = 1.0f64 - value;
+    let amount: f64 = 1.0f64 - clamp(value, 0.0f64, 1.0f64);
 
     for (x, y, pixel) in out.enumerate_pixels_mut() {
         let p = image.get_pixel(x, y);

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -40,6 +40,7 @@ pub use self::colorops:: {
     grayscale,
     invert,
     contrast,
+    sepia,
     brighten,
     ColorMap,
     BiLevel,


### PR DESCRIPTION
sepia filter from webkit

css equivalent:
`filter: sepia(100%)`

normal:
![test](https://cloud.githubusercontent.com/assets/4501195/19867952/3bc8bf7c-9fa6-11e6-8b81-4f6a24c6921f.jpg)


sepia(1.0): // 0.0 min to 1.0 max
![test2](https://cloud.githubusercontent.com/assets/4501195/19868120/facb08ee-9fa6-11e6-8a9e-5d18a276ae22.png)
