### PR TITLE
Fix building of benchmarks.

### DIFF
--- a/benches/load.rs
+++ b/benches/load.rs
@@ -1,4 +1,4 @@
-#[cfg(benchmarks)]
+#![cfg(feature = "benchmarks")]
 #![feature(test)]
 
 extern crate image;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -614,7 +614,7 @@ mod test {
 
     use super::{ImageBuffer, RgbImage, GrayImage, ConvertBuffer, Pixel};
     use color;
-    #[cfg(benchmarks)]
+    #[cfg(feature = "benchmarks")]
     use test;
 
     #[test]
@@ -647,7 +647,7 @@ mod test {
     }
 
     #[bench]
-    #[cfg(benchmarks)]
+    #[cfg(feature = "benchmarks")]
     fn bench_conversion(b: &mut test::Bencher) {
         let mut a: RgbImage = ImageBuffer::new(1000, 1000);
         for mut p in a.pixels_mut() {

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -677,11 +677,11 @@ pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
 
 #[cfg(test)]
 mod bench {
-    #[cfg(benchmarks)]
+    #[cfg(feature = "benchmarks")]
     use test;
 
     #[bench]
-    #[cfg(benchmarks)]
+    #[cfg(feature = "benchmarks")]
     fn bench_conversion(b: &mut test::Bencher) {
         let a = super::DynamicImage::ImageRgb8(::ImageBuffer::new(1000, 1000));
         b.iter(|| {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -468,14 +468,14 @@ pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32)
 
 #[cfg(test)]
 mod tests {
-    #[cfg(benchmarks)]
+    #[cfg(feature = "benchmarks")]
     use test;
     use buffer::{ImageBuffer, RgbImage};
     use super::{resize, FilterType};
     use std::path::Path;
 
     #[bench]
-    #[cfg(all(benchmarks, feature = "png_codec"))]
+    #[cfg(all(feature = "benchmarks", feature = "png_codec"))]
     fn bench_resize(b: &mut test::Bencher) {
         let img = ::open(&Path::new("./examples/fractal.png")).unwrap();
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(missing_copy_implementations)]
-#![cfg_attr(all(test, benchmarks), feature(test))]
+#![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 
 extern crate byteorder;
 extern crate num_iter;
@@ -13,7 +13,7 @@ extern crate num_rational;
 extern crate num_traits;
 #[macro_use]
 extern crate enum_primitive;
-#[cfg(all(test, benchmarks))]
+#[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
 
 use std::io::Write;


### PR DESCRIPTION
When `benchmarks` feature is enabled in cargo, it be passed to rustc as `feature="benchmarks"` configuration option, not just `benchmarks`.