### PR TITLE
Use docs.rs for documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,3 @@ script:
         if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi;
         cargo doc -v;
       fi
-after_success: |
-    [ $TRAVIS_BRANCH = master ] &&
-    [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo doc &&
-    echo '<meta http-equiv=refresh content=0;url=image/index.html>' > target/doc/index.html &&
-    pip install --user ghp-import &&
-    ghp-import -n target/doc &&
-    git push -fq https://${GH_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG}.git gh-pages > /dev/null 2>&1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.11.0"
+version = "0.11.1"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [
@@ -9,7 +9,7 @@ authors = [
     "nwin",
     "TyOverby <ty@pre-alpha.com>"]
 readme = "README.md"
-documentation = "http://www.piston.rs/image/image/index.html"
+documentation = "https://docs.rs/image"
 repository = "https://github.com/PistonDevelopers/image.git"
 homepage = "https://github.com/PistonDevelopers/image"
 exclude = [

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ extern crate image;
 
 ## 1. Documentation
 
-http://www.piston.rs/image/image/index.html
+https://docs.rs/image
 
 ## 2. Supported Image Formats
 ```image``` provides implementations of common image format encoders and decoders.


### PR DESCRIPTION
`image` now uses docs.rs for hosting the documentation. Bump to 0.11.1 to make this change visible on crates.io.