### PR TITLE
Disable default features on num-rational.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./src/lib.rs"
 [dependencies]
 byteorder = "1.0.0"
 num-iter = "0.1.32"
-num-rational = "0.1.32"
+num-rational = { version = "0.1.32", default-features = false }
 num-traits = "0.1.32"
 enum_primitive = "0.1.0"
 glob = "0.2.10"


### PR DESCRIPTION
In particular, this removes the dependency on num-bigint.