### PR TITLE
Make JPEG encoder output valid images again.

### DIFF
--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -375,6 +375,10 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
             try!(self.writer.write_segment(DQT, Some(&buf)));
         }
 
+        build_huffman_segment(&mut buf, DCCLASS, LUMADESTINATION,
+                              &STD_LUMA_DC_CODE_LENGTHS, &STD_LUMA_DC_VALUES);
+        try!(self.writer.write_segment(DHT, Some(&buf)));
+
         build_huffman_segment(&mut buf, ACCLASS, LUMADESTINATION,
                               &STD_LUMA_AC_CODE_LENGTHS, &STD_LUMA_AC_VALUES);
         try!(self.writer.write_segment(DHT, Some(&buf)));

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -667,3 +667,45 @@ fn copy_blocks_gray(source: &[u8],
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use super::JPEGEncoder;
+    use super::super::JPEGDecoder;
+    use color::ColorType;
+    use image::{ImageDecoder, DecodingResult};
+
+    #[test]
+    fn roundtrip_sanity_check() {
+        // create a 1x1 8-bit image buffer containing a single red pixel
+        let img = [255u8, 0, 0];
+
+        // encode it into a memory buffer
+        let mut encoded_img = Vec::new();
+        {
+            let mut encoder =
+                JPEGEncoder::new_with_quality(&mut encoded_img, 100);
+            encoder.encode(&img, 1, 1, ColorType::RGB(8))
+                .expect("Could not encode image");
+        }
+
+        // decode it from the memory buffer
+        {
+            let mut decoder =
+                JPEGDecoder::new(Cursor::new(&encoded_img));
+            match decoder.read_image().expect("Could not decode image") {
+                DecodingResult::U8(decoded) => {
+                    // note that, even with the encode quality set to 100, we
+                    // do not get the same image back. Therefore, we're going
+                    // to assert that it's at least red-ish:
+                    assert_eq!(3, decoded.len());
+                    assert!(decoded[0] > 0x80);
+                    assert!(decoded[1] < 0x80);
+                    assert!(decoded[2] < 0x80);
+                },
+                _ => panic!("Image did not decode as 8-bit"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #618. It looks like commit 2c06a405ac7e3a04d139c1de16d07263c4a13573
stopped emitting the DC table by accident, resulting in JPEG files missing
huffman table 0.