### PR TITLE
dynimage: uncomment the catch-all arm

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -629,7 +629,7 @@ pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIm
         image::ImageFormat::HDR => decoder_to_image(try!(hdr::HDRAdapter::new(BufReader::new(r)))),
         #[cfg(feature = "ppm")]
         image::ImageFormat::PPM => decoder_to_image(try!(ppm::PPMDecoder::new(BufReader::new(r)))),
-//        _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
+        _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }
 


### PR DESCRIPTION
When built without all of the features enabled, this arm is required.

---
Fixes the build following #617.