### PR TITLE
Enable encoding grayscale BMP images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://docs.rs/image
 | PNG    | All supported color types | Same as decoding|
 | JPEG   | Baseline and progressive | Baseline JPEG |
 | GIF    | Yes | Yes |
-| BMP    | Yes | RGB(8) |
+| BMP    | Yes | RGB(8), RGBA(8), Gray(8), GrayA(8) |
 | ICO    | Yes | Yes |
 | TIFF   | Baseline(no fax and packbits support) + LZW | No |
 | Webp   | Lossy(Luma channel only) | No |

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -26,13 +26,14 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
                   c: color::ColorType) -> io::Result<()> {
 
         let bmp_header_size = 14;
-        let dib_header_size = 40;
+        let dib_header_size = 40; // using BITMAPINFOHEADER
 
-        let (raw_pixel_size, written_pixel_size) = try!(get_pixel_info(&c));
+        let (raw_pixel_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(&c));
         let row_pad_size = (4 - (width * written_pixel_size) % 4) % 4; // each row must be padded to a multiple of 4 bytes
 
         let image_size = width * height * written_pixel_size + (height * row_pad_size);
-        let file_size = bmp_header_size + dib_header_size + image_size;
+        let palette_size = palette_color_count * 4; // all palette colors are BGRA
+        let file_size = bmp_header_size + dib_header_size + palette_size + image_size;
 
         // write BMP header
         try!(self.writer.write_u8('B' as u8));
@@ -40,25 +41,26 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         try!(self.writer.write_u32::<LittleEndian>(file_size)); // file size
         try!(self.writer.write_u16::<LittleEndian>(0)); // reserved 1
         try!(self.writer.write_u16::<LittleEndian>(0)); // reserved 2
-        try!(self.writer.write_u32::<LittleEndian>(bmp_header_size + dib_header_size)); // image data offset
+        try!(self.writer.write_u32::<LittleEndian>(bmp_header_size + dib_header_size + palette_size)); // image data offset
 
         // write DIB header
         try!(self.writer.write_u32::<LittleEndian>(dib_header_size));
         try!(self.writer.write_i32::<LittleEndian>(width as i32));
         try!(self.writer.write_i32::<LittleEndian>(height as i32));
         try!(self.writer.write_u16::<LittleEndian>(1)); // color planes
-        try!(self.writer.write_u16::<LittleEndian>(24)); // 24 bpp
+        try!(self.writer.write_u16::<LittleEndian>((written_pixel_size * 8) as u16)); // bits per pixel
         try!(self.writer.write_u32::<LittleEndian>(0)); // compression method - no compression
         try!(self.writer.write_u32::<LittleEndian>(image_size));
         try!(self.writer.write_i32::<LittleEndian>(0)); // horizontal ppm
         try!(self.writer.write_i32::<LittleEndian>(0)); // vertical ppm
-        try!(self.writer.write_u32::<LittleEndian>(0)); // color palette size - no palette
+        try!(self.writer.write_u32::<LittleEndian>(palette_color_count));
         try!(self.writer.write_u32::<LittleEndian>(0)); // all colors are important
 
         // write image data
         match c {
             color::ColorType::RGB(8) |
             color::ColorType::RGBA(8) => try!(self.encode_rgb(&image, width, height, row_pad_size, raw_pixel_size)),
+            color::ColorType::Gray(8) => try!(self.encode_gray(&image, width, height, row_pad_size)),
             _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, &get_unsupported_error_message(&c)[..])),
         }
 
@@ -83,9 +85,42 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
                 // alpha is never written as it's not widely supported
             }
 
-            for _ in 0..row_pad_size {
-                try!(self.writer.write_u8(0));
+            try!(self.write_row_pad(row_pad_size));
+        }
+
+        Ok(())
+    }
+
+    fn encode_gray(&mut self, image: &[u8], width: u32, height: u32, row_pad_size: u32) -> io::Result<()> {
+        // write grayscale palette
+        for val in 0..256 {
+            // each color is written as BGRA, where A is always 0 and since only grayscale is being written, B = G = R = index
+            let val = val as u8;
+            try!(self.writer.write_u8(val));
+            try!(self.writer.write_u8(val));
+            try!(self.writer.write_u8(val));
+            try!(self.writer.write_u8(0));
+        }
+
+        // write image data
+        for row in 0..height {
+            // from the bottom up
+            let row_start = (height - row - 1) * width;
+            for col in 0..width {
+                let pixel_start = (row_start + col) as usize;
+                // color value is equal to the palette index
+                try!(self.writer.write_u8(image[pixel_start]));
             }
+
+            try!(self.write_row_pad(row_pad_size));
+        }
+
+        Ok(())
+    }
+
+    fn write_row_pad(&mut self, row_pad_size: u32) -> io::Result<()> {
+        for _ in 0..row_pad_size {
+            try!(self.writer.write_u8(0));
         }
 
         Ok(())
@@ -93,14 +128,15 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
 }
 
 fn get_unsupported_error_message(c: &color::ColorType) -> String {
-    format!("Unsupported color type {:?}.  Supported types: RGB(8), RGBA(8).", c)
+    format!("Unsupported color type {:?}.  Supported types: RGB(8), RGBA(8), Gray(8).", c)
 }
 
-/// Returns a tuple representing the size in bytes of: (raw pixel data, written pixel data).
-fn get_pixel_info(c: &color::ColorType) -> io::Result<(u32, u32)> {
+/// Returns a tuple representing: (raw pixel size, written pixel size, palette color count).
+fn get_pixel_info(c: &color::ColorType) -> io::Result<(u32, u32, u32)> {
     let sizes = match c {
-        &color::ColorType::RGB(8) => (3, 3),
-        &color::ColorType::RGBA(8) => (4, 3),
+        &color::ColorType::RGB(8) => (3, 3, 0),
+        &color::ColorType::RGBA(8) => (4, 3, 0),
+        &color::ColorType::Gray(8) => (1, 1, 256),
         _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, &get_unsupported_error_message(&c)[..])),
     };
 
@@ -153,5 +189,22 @@ mod tests {
     fn round_trip_3px_rgb() {
         let image = [0u8; 3 * 3 * 3]; // 3x3 pixels, 3 bytes per pixel
         let _decoded = round_trip_image(&image, 3, 3, ColorType::RGB(8));
+    }
+
+    #[test]
+    fn round_trip_gray() {
+        let image = [0u8, 1, 2]; // 3 pixels
+        let decoded = round_trip_image(&image, 3, 1, ColorType::Gray(8));
+        // should be read back as 3 RGB pixels
+        assert_eq!(9, decoded.len());
+        assert_eq!(0, decoded[0]);
+        assert_eq!(0, decoded[1]);
+        assert_eq!(0, decoded[2]);
+        assert_eq!(1, decoded[3]);
+        assert_eq!(1, decoded[4]);
+        assert_eq!(1, decoded[5]);
+        assert_eq!(2, decoded[6]);
+        assert_eq!(2, decoded[7]);
+        assert_eq!(2, decoded[8]);
     }
 }

--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -1,6 +1,6 @@
-//!  Decoding of BMP Images
+//!  Decoding and Encoding of BMP Images
 //!
-//!  A decoder for BMP (Windows Bitmap) images
+//!  A decoder and encoder for BMP (Windows Bitmap) images
 //!
 //!  # Related Links
 //!  * https://msdn.microsoft.com/en-us/library/windows/desktop/dd183375%28v=vs.85%29.aspx


### PR DESCRIPTION
As a follow-up to #646, this adds the ability to encode grayscale BMP images.  Alpha channel handling is the same as for RGB BMP files; that is the alpha is stripped off because it's not a widely supported feature.

In addition to the unit tests, I've also manually verified the fractal example from the README works with luma-encoded BMP images.