### PR TITLE
Fix tiff Grey(16) support

### DIFF
--- a/src/tiff/decoder/mod.rs
+++ b/src/tiff/decoder/mod.rs
@@ -463,10 +463,7 @@ impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
             self.width  as usize
             * self.height as usize
             * self.bits_per_sample.iter().count();
-        let mut result = match (self.bits_per_sample.iter()
-                                               .cloned()
-                                               .max()
-                                               .unwrap_or(8) as f32/8.0).ceil() as u8 {
+        let mut result = match self.bits_per_sample.iter().cloned().max().unwrap_or(8) {
             n if n <= 8 => DecodingResult::U8(Vec::with_capacity(buffer_size)),
             n if n <= 16 => DecodingResult::U16(Vec::with_capacity(buffer_size)),
             n => return Err(


### PR DESCRIPTION
Currently, `image` produces the (incorrect) error message somewhere along the lines of "Grey(16) is not supported for tiff". This is because of a wacky artifact of code - a DecodingResult::U8 is produced (due to the code edited in this PR), but Grey(16) is the image type, so a [match block falls through](https://github.com/khyperia/image/blob/f23fef81cf92325f1e793b7343f540bf8eaeb94e/src/tiff/decoder/mod.rs#L434) and an error is produced.

U8 is selected because of some strange logic to divide by 8 - I'm guessing that 16 bit images were always broken, and "n" is actually 1 in the case of 8 bit images - 2 in the case of 16 bit images (which is less than 8, so U8 is selected).

Tested manually. Seems like #545 or something similar should be implemented to make sure 16 bit tiffs aren't regressed again.

I guess this also resolves #426 ?