### PR TITLE
Resize fixes

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -109,7 +109,7 @@ pub fn catmullrom_kernel(x: f32) -> f32 {
 /// Also known as BiLinear sampling in two dimensions.
 pub fn triangle_kernel(x: f32) -> f32 {
     if x.abs() < 1.0 {
-        1.0 - x
+        1.0 - x.abs()
     } else {
         0.0
     }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -154,16 +154,53 @@ fn horizontal_sample<I, P, S>(image: &I, new_width: u32,
             1.0
         };
 
-        let filter_radius = (filter.support * filter_scale).ceil();
+        let filter_radius = filter.support * filter_scale;
 
         for outx in 0..new_width {
 
-            let inputx = (outx as f32 + 0.5) * ratio;
+            // Find the point in the input image corresponding to the centre
+            // of the current pixel in the output image.
+            //
+            // Then go half a pixel to the left (hence the `- 0.5`).
+            //
+            // The reason for subtracting 0.5 is because the filter kernel
+            // treats the centre of a pixel as 0. When finding the left and
+            // right limits below, we're interested in the range of input
+            // pixels whose colour can influence the colour of the current
+            // output pixel. This is equivalent to the range of input
+            // pixels for which inputx lies within the filter_radius-sized
+            // region centered at the centre of that pixel. Subtracting
+            // 0.5 here simplifies the rounding operations below.
+            //
+            let inputx = (outx as f32 + 0.5) * ratio - 0.5;
 
+            // Find the index of the left-most input pixel which can influence
+            // the colour of the current output pixel. A point on the right
+            // side of a pixel is considered to be part of that pixel.
             let left  = (inputx - filter_radius).ceil() as i64;
             let left  = clamp(left, 0, width as i64 - 1) as u32;
 
-            let right = (inputx + filter_radius).floor() as i64;
+            // Find the index of the right-most input pixel which can influence
+            // the colour of the current output pixel. A point on the left side
+            // of a pixel is NOT considered to be part of that pixel. This is
+            // important because:
+            //  - If we included the point in both neighbouring pixels it would
+            //    force the output pixel to be influenced be both input pixels,
+            //    and force filters which don't desire this (e.g. Nearest),
+            //    to make sure they only sample from one side in such cases.
+            //  - If we included the point in neither neighbouring pixel it
+            //    would cause output pixels corresponding to input pixel
+            //    boundaries to be black regardless of the input pixel colours.
+            //
+            // The choice of right vs left is arbitrary.
+            let right = {
+                let real_right = inputx + filter_radius;
+                if real_right.fract() == 0.0 {
+                    (real_right - 1.0) as i64
+                } else {
+                    real_right.floor() as i64
+                }
+            };
             let right = clamp(right, 0, width as i64 - 1) as u32;
 
             let mut sum = (0., 0., 0., 0.);
@@ -234,15 +271,27 @@ fn vertical_sample<I, P, S>(image: &I, new_height: u32,
             1.0
         };
 
-        let filter_radius = (filter.support * filter_scale).ceil();
+        let filter_radius = filter.support * filter_scale;
 
         for outy in 0..new_height {
-            let inputy = (outy as f32 + 0.5) * ratio;
+
+            // For an explanation of this algorithm, see the comments
+            // in horizontal_sample.
+
+            let inputy = (outy as f32 + 0.5) * ratio - 0.5;
 
             let left  = (inputy - filter_radius).ceil() as i64;
             let left  = clamp(left, 0, height as i64 - 1) as u32;
 
-            let right = (inputy + filter_radius).floor() as i64;
+            let right = {
+                // A point above a pixel is NOT part of that pixel.
+                let real_right = inputy + filter_radius;
+                if real_right.fract() == 0.0 {
+                    (real_right - 1.0) as i64
+                } else {
+                    real_right.floor() as i64
+                }
+            };
             let right = clamp(right, 0, height as i64 - 1) as u32;
 
             let mut sum = (0., 0., 0., 0.);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -203,14 +203,13 @@ fn horizontal_sample<I, P, S>(image: &I, new_width: u32,
             };
             let right = clamp(right, 0, width as i64 - 1) as u32;
 
-            let mut sum = (0., 0., 0., 0.);
+            let mut sum = 0.;
 
             let mut t = (0., 0., 0., 0.);
 
             for i in left..right + 1 {
                 let w = (filter.kernel)((i as f32 - inputx) / filter_scale);
-                let w = (w, w, w, w);
-                sum.0 += w.0; sum.1 += w.1; sum.2 += w.2; sum.3 += w.3;
+                sum += w;
 
                 let x0  = clamp(i, 0, width - 1);
                 let p = image.get_pixel(x0, y);
@@ -223,11 +222,11 @@ fn horizontal_sample<I, P, S>(image: &I, new_width: u32,
                     NumCast::from(k4).unwrap()
                 );
 
-                t.0 += vec.0 * w.0; t.1 += vec.1 * w.1;
-                t.2 += vec.2 * w.2; t.3 += vec.3 * w.3;
+                t.0 += vec.0 * w; t.1 += vec.1 * w;
+                t.2 += vec.2 * w; t.3 += vec.3 * w;
             }
 
-            let (t1, t2, t3, t4) = (t.0 / sum.0, t.1 / sum.1, t.2 / sum.2, t.3 / sum.3);
+            let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             let t = Pixel::from_channels(
                 NumCast::from(clamp(t1, 0.0, max)).unwrap(),
                 NumCast::from(clamp(t2, 0.0, max)).unwrap(),
@@ -294,14 +293,13 @@ fn vertical_sample<I, P, S>(image: &I, new_height: u32,
             };
             let right = clamp(right, 0, height as i64 - 1) as u32;
 
-            let mut sum = (0., 0., 0., 0.);
+            let mut sum = 0.;
 
             let mut t = (0., 0., 0., 0.);
 
             for i in left..right + 1 {
                 let w = (filter.kernel)((i as f32 - inputy) / filter_scale);
-                let w = (w, w, w, w);
-                sum.0 += w.0; sum.1 += w.1; sum.2 += w.2; sum.3 += w.3;
+                sum += w;
 
                 let y0  = clamp(i, 0, height - 1);
                 let p = image.get_pixel(x, y0);
@@ -314,11 +312,11 @@ fn vertical_sample<I, P, S>(image: &I, new_height: u32,
                     NumCast::from(k4).unwrap()
                 );
 
-                t.0 += vec.0 * w.0; t.1 += vec.1 * w.1;
-                t.2 += vec.2 * w.2; t.3 += vec.3 * w.3;
+                t.0 += vec.0 * w; t.1 += vec.1 * w;
+                t.2 += vec.2 * w; t.3 += vec.3 * w;
             }
 
-            let (t1, t2, t3, t4) = (t.0 / sum.0, t.1 / sum.1, t.2 / sum.2, t.3 / sum.3);
+            let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             let t = Pixel::from_channels(
                 NumCast::from(clamp(t1, 0.0, max)).unwrap(),
                 NumCast::from(clamp(t2, 0.0, max)).unwrap(),


### PR DESCRIPTION
This fixes some problems I noticed with resizing images. I'll present some examples of images resized by this library prior to these changes, then show how they look after these changes. To make pixels visible, I've scaled each image up to 256x256 with no interpolation.

We'll start with this 16x16 image:
![original](https://user-images.githubusercontent.com/417118/27766401-b3f42ac4-5f11-11e7-9782-afdfb950ebff.png)

## Problems

### Nearest neighbour scaling up also translates output

Double it's size using `FilterType::Nearest`:
```
let scaled = original.resize(32, 32, FilterType::Nearest);
```
Prior to this change, the output image was translated up and to the left by 1 pixel:
![scale-broken](https://user-images.githubusercontent.com/417118/27766422-7280a864-5f12-11e7-92d8-a00627ac0657.png)

After this change it no longer translates:
![scale-fixed](https://user-images.githubusercontent.com/417118/27766432-c0bedc44-5f12-11e7-839f-6b17bcea161b.png)

### Nearest neighbour scaling to original size produces artefacts

```
let scaled = original.resize(16, 16, FilterType::Nearest);
```
Prior to this change, each pixel's colour was influenced by its neighbour:
![same-size-broken](https://user-images.githubusercontent.com/417118/27766446-63415122-5f13-11e7-97c2-77c1c3984b70.png)

After this change it looks like the original image:
![same-size-fixed](https://user-images.githubusercontent.com/417118/27766452-85bf2c10-5f13-11e7-98f3-74d702a48333.png)

### Nearest neighbour scaling down produces artefacts

```
let scaled = original.resize(8, 8, FilterType::Nearest);
```

Prior to this change, output pixels are influenced by input pixel neighbours:
![reduce-broken](https://user-images.githubusercontent.com/417118/27766474-4e8122ca-5f14-11e7-82a8-cf1c873e4147.png)

After this change no new colours are introduced:
![reduce-fixed](https://user-images.githubusercontent.com/417118/27766481-6d3d4270-5f14-11e7-979f-6dc4510b10d5.png)

### Scaling with triangle interpolation is asymetric

```
let scaled = original.resize(32, 32, FilterType::Triangle);
```

Before:
![triangle-broken](https://user-images.githubusercontent.com/417118/27766502-43438d20-5f15-11e7-8227-2ab812005218.png)

After:
![triangle-fixed](https://user-images.githubusercontent.com/417118/27766503-47d3704e-5f15-11e7-8c1c-fa1e38cc6217.png)

## Solutions

The triangle filter solution was easy - it was just missing a `.abs()`.

The problems with nearest-neighbour were indicative of deeper problems with image sampling. Specifically:
 - The rounding off of the left and right sides of the sample window (`left` and `right`), and the calculation of the value to pass to `filter.kernel` was off by 0.5.
 - When an output pixel position corresponded to the boundary of two input pixels, nearest neighbour would sample and average out both pixels. I changed sampling to break ties by always preferring pixels to the left and above the border.
 - The code used to scale up the filter radius when down-sampling. This produced artefacts with nearest neighbour when down-sampling, as it was allowing multiple pixels to influence the colour of each output pixel. I remove the code that implements this.

I also added detailed comments explaining the calculations that I changed, and removed some unnecessary duplication left over from when this code used SIMD.

I'm happy to explain my changes in more detail if anyone has questions. What's the best way to test that the more complex `FilterType`s still work after these changes?