### PR TITLE
TGA decoder taking screen origin bit into consideration

### DIFF
--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -387,23 +387,19 @@ impl<R: Read + Seek> TGADecoder<R> {
         if !screen_origin_bit {
             let num_bytes = pixels.len();
 
-            // Make a copy of the current pixels that we can take values from when flipping.
-            let mut pixels_copy = Vec::with_capacity(num_bytes);
-            for i in 0..pixels.len() {
-                pixels_copy.push(pixels[i]);
-            }
-
             let width_bytes = num_bytes / self.height;
 
             // Flip the image vertically.
-            for vertical_index in 0..self.height {
+            for vertical_index in 0..(self.height / 2) {
                 let vertical_target = (self.height - vertical_index) * width_bytes - width_bytes;
 
                 for horizontal_index in 0..width_bytes {
                     let source = vertical_index * width_bytes + horizontal_index;
                     let target = vertical_target + horizontal_index;
 
-                    pixels[target] = pixels_copy[source];
+                    let stash = pixels[target];
+                    pixels[target] = pixels[source];
+                    pixels[source] = stash;
                 }
             }
         }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -314,6 +314,9 @@ impl<R: Read + Seek> TGADecoder<R> {
         }
 
         self.reverse_encoding(&mut pixel_data);
+
+        self.flip_vertically(&mut pixel_data);
+        
         Ok(pixel_data)
     }
 


### PR DESCRIPTION
The bit in position 5 of the image descriptor byte is the screen origin bit. If it's 1, the origin is in the top left corner, and if it's 0, the origin is in the bottom left corner. This pull request adds a function to the TGA decoder that checks the bit, and if it's 0, flips the image vertically.

This fixes the following issue, where you can also find code and images to test the commit with: https://github.com/PistonDevelopers/image/issues/663

This is my first pull request in like 5 years, so please let me know if I'm not doing something right. :)