### PR TITLE
new error class in more recent rust releases?

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -638,7 +638,6 @@ pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIm
         image::ImageFormat::HDR => decoder_to_image(try!(hdr::HDRAdapter::new(BufReader::new(r)))),
         #[cfg(feature = "ppm")]
         image::ImageFormat::PPM => decoder_to_image(try!(ppm::PPMDecoder::new(BufReader::new(r)))),
-        _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }
 


### PR DESCRIPTION
Before Patch:

   Compiling image v0.14.0 (file:///Users/andrewjohnson/pd/image)

    error[E0001]: unreachable pattern
       --> src/dynimage.rs:641:9
        |
    641 |         _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
        |         ^ this is an unreachable pattern
    
    error: aborting due to previous error
    
    error: Could not compile `image`.


After: Running with latest rust version, recognizes exhaustive matching with wildcard as error now.