### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ fn main() {
 
         let mut i = 0;
 
-        for t in (0..max_iterations) {
+        for t in 0..max_iterations {
             if z.norm() > 2.0 {
                 break
             }


### PR DESCRIPTION
Remove unnecessary parentheses from iteration in the Julia set example to avoid a compiler warning.