### PR TITLE
Use FnMut not Fn in most places

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -71,30 +71,30 @@ pub trait Pixel: Copy + Clone {
     fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn map<F>(&self, f: F) -> Self where F: Fn(Self::Subpixel) -> Self::Subpixel;
+    fn map<F>(&self, f: F) -> Self where F: FnMut(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel.
-    fn apply<F>(&mut self, f: F) where F: Fn(Self::Subpixel) -> Self::Subpixel;
+    fn apply<F>(&mut self, f: F) where F: FnMut(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel except the alpha channel.
     /// Apply the function ```g``` to the alpha channel.
     fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
-        where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
+        where F: FnMut(Self::Subpixel) -> Self::Subpixel, G: FnMut(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel except the alpha channel.
     /// Apply the function ```g``` to the alpha channel. Works in-place.
     fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
-        where F: Fn(Self::Subpixel) -> Self::Subpixel, G: Fn(Self::Subpixel) -> Self::Subpixel;
+        where F: FnMut(Self::Subpixel) -> Self::Subpixel, G: FnMut(Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise.
     fn map2<F>(&self, other: &Self, f: F) -> Self
-        where F: Fn(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
+        where F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise. Works in-place.
     fn apply2<F>(&mut self, other: &Self, f: F)
-        where F: Fn(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
+        where F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
 
     /// Invert this pixel
     fn invert(&mut self);
@@ -512,9 +512,9 @@ where P::Subpixel: 'static {
 
     /// Constructs a new ImageBuffer by repeated application of the supplied function.
     /// The arguments to the function are the pixel's x and y coordinates.
-    pub fn from_fn<F>(width: u32, height: u32, f: F)
+    pub fn from_fn<F>(width: u32, height: u32, mut f: F)
                       -> ImageBuffer<P, Vec<P::Subpixel>>
-                      where F: Fn(u32, u32) -> P {
+                      where F: FnMut(u32, u32) -> P {
         let mut buf = ImageBuffer::new(width, height);
         for (x, y,  p) in buf.enumerate_pixels_mut() {
             *p = f(x, y)

--- a/src/color.rs
+++ b/src/color.rs
@@ -135,26 +135,26 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         pix
     }
 
-    fn map<F>(& self, f: F) -> $ident<T> where F: Fn(T) -> T {
+    fn map<F>(& self, f: F) -> $ident<T> where F: FnMut(T) -> T {
         let mut this = (*self).clone();
         this.apply(f);
         this
     }
 
-    fn apply<F>(&mut self, f: F) where F: Fn(T) -> T {
+    fn apply<F>(&mut self, mut f: F) where F: FnMut(T) -> T {
         for v in &mut self.data {
             *v = f(*v)
         }
     }
 
-    fn map_with_alpha<F, G>(&self, f: F, g: G) -> $ident<T> where F: Fn(T) -> T, G: Fn(T) -> T {
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> $ident<T> where F: FnMut(T) -> T, G: FnMut(T) -> T {
         let mut this = (*self).clone();
         this.apply_with_alpha(f, g);
         this
     }
 
     #[allow(trivial_casts)]
-    fn apply_with_alpha<F, G>(&mut self, f: F, g: G) where F: Fn(T) -> T, G: Fn(T) -> T {
+    fn apply_with_alpha<F, G>(&mut self, mut f: F, mut g: G) where F: FnMut(T) -> T, G: FnMut(T) -> T {
         for v in self.data[..$channels as usize-$alphas as usize].iter_mut() {
             *v = f(*v)
         }
@@ -164,13 +164,13 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         }
     }
 
-    fn map2<F>(&self, other: &Self, f: F) -> $ident<T> where F: Fn(T, T) -> T {
+    fn map2<F>(&self, other: &Self, f: F) -> $ident<T> where F: FnMut(T, T) -> T {
         let mut this = (*self).clone();
         this.apply2(other, f);
         this
     }
 
-    fn apply2<F>(&mut self, other: &$ident<T>, f: F) where F: Fn(T, T) -> T {
+    fn apply2<F>(&mut self, other: &$ident<T>, mut f: F) where F: FnMut(T, T) -> T {
         for (a, &b) in self.data.iter_mut().zip(other.data.iter()) {
             *a = f(*a, b)
         }

--- a/src/color.rs
+++ b/src/color.rs
@@ -174,7 +174,6 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         for (a, &b) in self.data.iter_mut().zip(other.data.iter()) {
             *a = f(*a, b)
         }
-
     }
 
     fn invert(&mut self) {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,8 +9,8 @@ use num_iter::range_step;
 
 
 #[inline(always)]
-pub fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, func: F)
-where F: Fn(u8, &mut[u8]) {
+pub fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, mut func: F)
+where F: FnMut(u8, &mut[u8]) {
     let pixels = buf.len()/channels*bit_depth as usize;
     let extra = pixels % 8;
     let entries = pixels / 8 + match extra {


### PR DESCRIPTION
Note, I'm quite new to rust, so this should be checked carefully by someone that knows what they're doing.  This is probably my 4th day playing with it (non consecutive).

I wanted to mutate a vector accumulating some other results while building an image buffer, and ran into `ImageBuffer::from_fn` wanting a `Fn` which does not allow mutation of the captured environment.  I believe this is the correct change by analogy to https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.map .

There are now just two occurrences of `Fn`:

* In `imageops::sample::Filter.kernel` (is this a reasonable way to identify that?), seems reasonable to have it be a `Fn` since the kernel should be as close to "pure" as possible.

* In `hdr_decoder::HDRDecoder.read_image_transform`, since it's using threadpools, shouldn't allow concurrent mutation of the closure environment, if I understand correctly.