### PR TITLE
Fix formatting warnings with commonmark enabled

### DIFF
--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -3,8 +3,8 @@
 //!  A decoder and encoder for BMP (Windows Bitmap) images
 //!
 //!  # Related Links
-//!  * https://msdn.microsoft.com/en-us/library/windows/desktop/dd183375%28v=vs.85%29.aspx
-//!  * https://en.wikipedia.org/wiki/BMP_file_format
+//!  * <https://msdn.microsoft.com/en-us/library/windows/desktop/dd183375%28v=vs.85%29.aspx>
+//!  * <https://en.wikipedia.org/wiki/BMP_file_format>
 //!
 
 pub use self::encoder::BMPEncoder;

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -296,7 +296,7 @@ impl DynamicImage {
     /// ```sigma``` is the amount to blur the image by.
     /// ```threshold``` is a control of how much to sharpen.
     ///
-    /// See https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
+    /// See <https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking>
     pub fn unsharpen(&self, sigma: f32, threshold: i32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::unsharpen(p, sigma, threshold))
     }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -3,8 +3,9 @@
 //!  GIF (Graphics Interchange Format) is an image format that supports lossless compression.
 //!
 //!  # Related Links
-//!  * http://www.w3.org/Graphics/GIF/spec-gif89a.txt - The GIF Specification
+//!  * <http://www.w3.org/Graphics/GIF/spec-gif89a.txt> - The GIF Specification
 //!
+
 extern crate gif;
 
 use std::io::{Read, Write};

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -127,11 +127,11 @@ impl RGBE8Pixel {
 
     /// Converts ```RGBE8Pixel``` into ```Rgb<T>``` with scale=1 and gamma=2.2
     ///
- 	/// color_ldr = (color_hdr*scale)^gamma
+    /// color_ldr = (color_hdr*scale)<sup>gamma</sup>
     ///
- 	/// # Panic
- 	///
- 	/// Panics when ```T::max_value()``` cannot be represented as f32.
+    /// # Panic
+    ///
+    /// Panics when ```T::max_value()``` cannot be represented as f32.
     #[inline]
     pub fn to_ldr<T: Primitive + Zero>(self) -> Rgb<T> {
         self.to_ldr_scale_gamma(1.0, 2.2)
@@ -139,7 +139,7 @@ impl RGBE8Pixel {
 
     /// Converts RGBE8Pixel into Rgb<T> using provided scale and gamma
     ///
-    /// color_ldr = (color_hdr*scale)^gamma
+    /// color_ldr = (color_hdr*scale)<sup>gamma</sup>
     ///
     /// # Panic
     ///
@@ -574,10 +574,14 @@ pub struct HDRMetadata {
     /// First pair tells how resulting pixel coordinates change along a scanline.
     /// Second pair tells how they change from one scanline to the next.
     pub orientation: ((i8, i8), (i8, i8)),
-    /// Divide color values by exposure to get to get physical radiance in watts/steradian/m^2
+    /// Divide color values by exposure to get to get physical radiance in
+    /// watts/steradian/m<sup>2</sup>
+    ///
     /// Image may not contain physical data, even if this field is set.
     pub exposure: Option<f32>,
-    /// Divide color values by corresponing tuple member (r, g, b) to get to get physical radiance in watts/steradian/m^2
+    /// Divide color values by corresponing tuple member (r, g, b) to get to get physical radiance
+    /// in watts/steradian/m<sup>2</sup>
+    ///
     /// Image may not contain physical data, even if this field is set.
     pub color_correction: Option<(f32,f32,f32)>,
     /// Pixel height divided by pixel width

--- a/src/hdr/mod.rs
+++ b/src/hdr/mod.rs
@@ -3,8 +3,9 @@
 //!  A decoder for Radiance HDR images
 //!
 //!  # Related Links
-//!  * http://radsite.lbl.gov/radiance/refer/filefmts.pdf
-//!  * http://www.graphics.cornell.edu/~bjw/rgbe/rgbe.c
+//!
+//!  * <http://radsite.lbl.gov/radiance/refer/filefmts.pdf>
+//!  * <http://www.graphics.cornell.edu/~bjw/rgbe/rgbe.c>
 //!
 
 extern crate scoped_threadpool;

--- a/src/ico/mod.rs
+++ b/src/ico/mod.rs
@@ -3,8 +3,8 @@
 //!  A decoder and encoder for ICO (Windows Icon) image container files.
 //!
 //!  # Related Links
-//!  * https://msdn.microsoft.com/en-us/library/ms997538.aspx
-//!  * https://en.wikipedia.org/wiki/ICO_%28file_format%29
+//!  * <https://msdn.microsoft.com/en-us/library/ms997538.aspx>
+//!  * <https://en.wikipedia.org/wiki/ICO_%28file_format%29>
 
 pub use self::decoder::ICODecoder;
 pub use self::encoder::ICOEncoder;

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -49,8 +49,8 @@ pub use self::colorops:: {
 };
 
 mod affine;
-/// Public only because of Rust bug:
-/// https://github.com/rust-lang/rust/issues/18241
+// Public only because of Rust bug:
+// https://github.com/rust-lang/rust/issues/18241
 pub mod colorops;
 mod sample;
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -454,7 +454,7 @@ pub fn blur<I: GenericImage + 'static>(image: &I, sigma: f32)
 /// ```sigma``` is the amount to blur the image by.
 /// ```threshold``` is the threshold for the difference between
 ///
-/// See https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking
+/// See <https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking>
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32)
     -> ImageBuffer<P, Vec<S>>

--- a/src/jpeg/mod.rs
+++ b/src/jpeg/mod.rs
@@ -3,8 +3,8 @@
 //! JPEG (Joint Photographic Experts Group) is an image format that supports lossy compression.
 //! This module implements the Baseline JPEG standard.
 //!
-//! #Related Links
-//! * http://www.w3.org/Graphics/JPEG/itu-t81.pdf - The JPEG specification
+//! # Related Links
+//! * <http://www.w3.org/Graphics/JPEG/itu-t81.pdf> - The JPEG specification
 //!
 
 pub use self::decoder::JPEGDecoder;

--- a/src/math/nq.rs
+++ b/src/math/nq.rs
@@ -2,7 +2,7 @@
 //! See "Kohonen neural networks for optimal colour quantization"
 //! in "Network: Computation in Neural Systems" Vol. 5 (1994) pp 351-367.
 //! for a discussion of the algorithm.
-//! See also  http://www.acm.org/~dekker/NEUQUANT.HTML
+//! See also <http://www.acm.org/~dekker/NEUQUANT.HTML>
 
 /* NeuQuant Neural-Net Quantization Algorithm
  * ------------------------------------------

--- a/src/png.rs
+++ b/src/png.rs
@@ -4,7 +4,7 @@
 //! PNG (Portable Network Graphics) is an image format that supports lossless compression.
 //!
 //! # Related Links
-//! * http://www.w3.org/TR/PNG/ - The PNG Specification
+//! * <http://www.w3.org/TR/PNG/> - The PNG Specification
 //!
 
 extern crate png;

--- a/src/tga/mod.rs
+++ b/src/tga/mod.rs
@@ -1,7 +1,7 @@
 //! Decoding of TGA Images
 //!
 //! # Related Links
-//! http://googlesites.inequation.org/tgautilities
+//! <http://googlesites.inequation.org/tgautilities>
 
 /// A decoder for TGA images
 ///

--- a/src/tiff/mod.rs
+++ b/src/tiff/mod.rs
@@ -1,10 +1,10 @@
-//!  Decoding and Encoding of TIFF Images
+//! Decoding and Encoding of TIFF Images
 //!
-//!  TIFF (Tagged Image File Format) is a versatile image format that supports
-//!  lossless and lossy compression.
+//! TIFF (Tagged Image File Format) is a versatile image format that supports
+//! lossless and lossy compression.
 //!
-//!  # Related Links
-//!  * http://partners.adobe.com/public/developer/tiff/index.html - The TIFF specification
+//! # Related Links
+//! * <http://partners.adobe.com/public/developer/tiff/index.html> - The TIFF specification
 //!
 
 pub use self::decoder::TIFFDecoder;


### PR DESCRIPTION
This makes documentation work correctly with the new pulldown-cmark Markdown parser (rust-lang/rust#44229).