### PR TITLE
Add crates.io categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ readme = "README.md"
 documentation = "https://docs.rs/image"
 repository = "https://github.com/PistonDevelopers/image.git"
 homepage = "https://github.com/PistonDevelopers/image"
+categories = ["multimedia::images", "multimedia::encoding"]
 exclude = [
     "src/png/testdata/*",
     "examples/*",
     "tests/*",
 ]
+
 [lib]
 name = "image"
 path = "./src/lib.rs"


### PR DESCRIPTION
I noticed this crate didn't have any categories on crates.io. I figured at least `Multimedia::Images` and `Multimedia::Encoding` would be relevant. I'm not sure if `Multimedia` itself is automatically implied if these categories are present.