### PR TITLE
Improve support for ppm

### DIFF
--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -61,7 +61,7 @@ impl<R: Read> PPMDecoder<R> {
 
         for (_, byte) in mark_comments.filter(|ref e| e.0) {
             match byte {
-                Ok(b'\n') | Ok(b' ') | Ok(b'\r') | Ok(b'\t') => {
+                Ok(b'\t') | Ok(b'\n') | Ok(b'\x0b') | Ok(b'\x0c') | Ok(b'\r') | Ok(b' ') => {
                     if !bytes.is_empty() {
                         break // We're done as we already have some content
                     }

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -31,6 +31,10 @@ impl<R: Read> PPMDecoder<R> {
         let height = try!(PPMDecoder::read_next_u32(&mut buf));
         let maxwhite = try!(PPMDecoder::read_next_u32(&mut buf));
 
+        if !(maxwhite <= u16::max_value() as u32) {
+            return Err(ImageError::FormatError("Image maxval is not less or equal to 65535".to_string()))
+        }
+
         Ok(PPMDecoder {
             reader: buf,
             width: width,

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -27,6 +27,11 @@ impl<R: Read> PPMDecoder<R> {
             return Err(ImageError::FormatError("Expected magic constant for ppm, P3 or P6".to_string()));
         }
 
+        // Remove this once the reader can read plain ppm
+        if magic[1] == b'3' {
+            return Err(ImageError::FormatError("Plain format is not yet supported".to_string()))
+        }
+
         let width = try!(PPMDecoder::read_next_u32(&mut buf));
         let height = try!(PPMDecoder::read_next_u32(&mut buf));
         let maxwhite = try!(PPMDecoder::read_next_u32(&mut buf));

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 use std::io::BufReader;
 use std::io::Error as IoError;
+use std::ascii::AsciiExt;
 
 use color::{ColorType};
 use image::{DecodingResult, ImageDecoder, ImageResult, ImageError};
@@ -73,12 +74,16 @@ impl<R: Read> PPMDecoder<R> {
             return Err(ImageError::FormatError("Unexpected eof".to_string()))
         }
 
+        if !bytes.as_slice().is_ascii() {
+            return Err(ImageError::FormatError("Non ascii character in preamble"))
+        }
+
         String::from_utf8(bytes).map_err(|_| ImageError::FormatError("Couldn't read preamble".to_string()))
     }
 
     fn read_next_u32(reader: &mut BufReader<R>) -> ImageResult<u32> {
         let s = try!(PPMDecoder::read_next_string(reader));
-        s.parse::<u32>().map_err(|_| ImageError::FormatError("Couldn't read preamble".to_string()))
+        s.parse::<u32>().map_err(|_| ImageError::FormatError("Invalid number in preamble".to_string()))
     }
 }
 

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -49,14 +49,10 @@ impl<R: Read> PPMDecoder<R> {
                     Err(err) => return Some((*partof, Err(err))),
                     Ok(byte) => byte,
                 };
-                if *partof && byte == b'#' {
-                    *partof = false;
-                    return Some((false, Ok(byte)));
-                } else if !*partof && (byte == b'\r' || byte == b'\n') {
-                    *partof = true;
-                    return Some((false, Ok(byte)));
-                }
-                return Some((*partof, Ok(byte)));
+                let cur_enabled = *partof && byte != b'#';
+                let next_enabled = cur_enabled || (byte == b'\r' || byte == b'\n');
+                *partof = next_enabled;
+                return Some((cur_enabled, Ok(byte)));
             });
 
         for (_, byte) in mark_comments.filter(|ref e| e.0) {

--- a/src/ppm/mod.rs
+++ b/src/ppm/mod.rs
@@ -92,16 +92,4 @@ mod test {
             }
         }
     }
-
-    #[test]
-    fn test_ppm_comment() {
-        // the following is a 1x1 white dot:
-        let buf = "P3\n# asdf\n1 1\n255 255 255 255".as_bytes();
-
-        let img = super::PPMDecoder::new(&buf[..]);
-        assert_eq!(img.is_ok(), true);
-
-        let img = img.unwrap().read_image();
-        assert_eq!(img.is_ok(), true);
-    }
 }


### PR DESCRIPTION
This fixes the following issues:
- Whitespace now includes all six character in the specification
- Comments are now handled correctly (fully ignored)
- Diagnostics when trying to read supported formats
  - Wrong magic value
  - `maxval` header parameter too large
  - Custom messages for several format issues  of the header
- Add a bunch of tests to PPMDecoder

Basically whatever is mentioned in #691 