### PR TITLE
Add other pnm (pbm, pgm, pam) decoders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ num-complex = "0.1.32"
 glob = "0.2.10"
 
 [features]
-default = ["gif_codec", "jpeg", "ico", "png_codec", "ppm", "tga", "tiff", "webp", "bmp", "hdr"]
+default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "tga", "tiff", "webp", "bmp", "hdr"]
 
 gif_codec = ["gif"]
 ico = ["bmp", "png_codec"]
 jpeg = ["jpeg-decoder"]
 png_codec = ["png"]
-ppm = []
+pnm = []
 tga = []
 tiff = []
 webp = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,14 @@ num-complex = "0.1.32"
 glob = "0.2.10"
 
 [features]
-default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "tga", "tiff", "webp", "bmp", "hdr"]
+default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "ppm", "tga", "tiff", "webp", "bmp", "hdr"]
 
 gif_codec = ["gif"]
 ico = ["bmp", "png_codec"]
 jpeg = ["jpeg-decoder"]
 png_codec = ["png"]
 pnm = []
+ppm = ["pnm"]
 tga = []
 tiff = []
 webp = []

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -6,6 +6,8 @@ use std::iter;
 use std::ascii::AsciiExt;
 use num_iter;
 
+#[cfg(feature = "pnm")]
+use pnm;
 #[cfg(feature = "ppm")]
 use ppm;
 #[cfg(feature = "gif_codec")]
@@ -567,7 +569,10 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
         "bmp" => image::ImageFormat::BMP,
         "ico" => image::ImageFormat::ICO,
         "hdr" => image::ImageFormat::HDR,
+        "pbm" => image::ImageFormat::PNM,
+        "pgm" => image::ImageFormat::PNM,
         "ppm" => image::ImageFormat::PPM,
+        "pam" => image::ImageFormat::PNM,
         format => return Err(image::ImageError::UnsupportedError(format!(
             "Image format image/{:?} is not supported.",
             format
@@ -638,11 +643,13 @@ pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIm
         image::ImageFormat::HDR => decoder_to_image(try!(hdr::HDRAdapter::new(BufReader::new(r)))),
         #[cfg(feature = "ppm")]
         image::ImageFormat::PPM => decoder_to_image(try!(ppm::PPMDecoder::new(BufReader::new(r)))),
+        #[cfg(feature = "pnm")]
+        image::ImageFormat::PNM => decoder_to_image(try!(pnm::PNMDecoder::new(BufReader::new(r)))),
         _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }
 
-static MAGIC_BYTES: [(&'static [u8], ImageFormat); 11] = [
+static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::PNG),
     (&[0xff, 0xd8, 0xff], ImageFormat::JPEG),
     (b"GIF89a", ImageFormat::GIF),
@@ -653,7 +660,13 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 11] = [
     (b"BM", ImageFormat::BMP),
     (&[0, 0, 1, 0], ImageFormat::ICO),
     (b"#?RADIANCE", ImageFormat::HDR),
+    (b"P1", ImageFormat::PNM),
+    (b"P2", ImageFormat::PNM),
+    (b"P3", ImageFormat::PNM),
+    (b"P4", ImageFormat::PNM),
+    (b"P5", ImageFormat::PNM),
     (b"P6", ImageFormat::PPM),
+    (b"P7", ImageFormat::PNM),
 ];
 
 /// Create a new image from a byte slice

--- a/src/image.rs
+++ b/src/image.rs
@@ -119,6 +119,7 @@ pub enum ImageFormat {
     WEBP,
 
     /// An Image in PPM Format
+    #[deprecated(since="0.17.0", note="Use the more general `PNM`")]
     PPM,
 
     /// An Image in general PNM Format

--- a/src/image.rs
+++ b/src/image.rs
@@ -121,6 +121,9 @@ pub enum ImageFormat {
     /// An Image in PPM Format
     PPM,
 
+    /// An Image in general PNM Format
+    PNM,
+
     /// An Image in TIFF Format
     TIFF,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub mod imageops;
 pub mod webp;
 #[cfg(feature = "pnm")]
 pub mod pnm;
-#[cfg(feature = "pnm")]
+#[cfg(feature = "ppm")]
 pub mod ppm;
 #[cfg(feature = "png_codec")]
 pub mod png;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,9 @@ pub mod imageops;
 // Image codecs
 #[cfg(feature = "webp")]
 pub mod webp;
-#[cfg(feature = "ppm")]
+#[cfg(feature = "pnm")]
+pub mod pnm;
+#[cfg(feature = "pnm")]
 pub mod ppm;
 #[cfg(feature = "png_codec")]
 pub mod png;

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -17,6 +17,19 @@ enum TupleType {
     Bit,
 }
 
+/// Denotes the category of the magic number
+#[derive(Clone, Copy)]
+pub enum PNMSubtype {
+    /// Magic numbers P1 and P4
+    Bitmap,
+    /// Magic numbers P2 and P5
+    Graymap,
+    /// Magic numbers P3 and P6
+    Pixmap,
+    /// Magic number P7
+    ArbitraryMap,
+}
+
 /// PNM decoder
 pub struct PNMDecoder<R> {
     reader: BufReader<R>,
@@ -25,6 +38,7 @@ pub struct PNMDecoder<R> {
     maxwhite: u32,
     tuple: TupleType,
     decoder: DecodeStrategy,
+    subtype: PNMSubtype,
 }
 
 impl<R: Read> PNMDecoder<R> {
@@ -58,6 +72,7 @@ impl<R: Read> PNMDecoder<R> {
             maxwhite: maxwhite,
             tuple: TupleType::RGB,
             decoder: decoder,
+            subtype: PNMSubtype::Pixmap,
         })
     }
 
@@ -204,6 +219,11 @@ impl<R: Read> PNMDecoder<R> {
         }
         let string = String::from_utf8(token).map_err(|_| ImageError::FormatError("Error parsing sample".to_string()))?;
         string.parse::<u32>().map_err(|_| ImageError::FormatError("Error parsing sample value".to_string()))
+    }
+
+    /// Get the pnm subtype, depending on the magic constant contained in the header
+    pub fn subtype(&self) -> PNMSubtype {
+        self.subtype
     }
 }
 

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -414,6 +414,7 @@ impl<R: Read> PNMDecoder<R> {
         self.subtype
     }
 
+    /// Whether samples are stored as binary or as decimal ascii
     pub fn encoding(&self) -> SampleEncoding {
         match self.subtype {
             PNMSubtype::ArbitraryMap => SampleEncoding::Binary,

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -541,14 +541,16 @@ TUPLTYPE BLACKANDWHITE
 ENDHDR
 \x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01";
         let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        let image = decoder.read_image().unwrap();
-        match image {
+        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
+        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        assert_eq!(decoder.maxwhite, 1);
+        assert_eq!(decoder.subtype, PNMSubtype::ArbitraryMap);
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
                      0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,]),
         }
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
     }
 
     /// Tests reading of a valid grayscale pam
@@ -565,14 +567,16 @@ TUPLTYPE GRAYSCALE
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
         let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        let image = decoder.read_image().unwrap();
-        match image {
+        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
+        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        assert_eq!(decoder.maxwhite, 255);
+        assert_eq!(decoder.subtype, PNMSubtype::ArbitraryMap);
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
                      0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]),
         }
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
     }
 
     /// Tests reading of a valid rgb pam
@@ -589,14 +593,16 @@ HEIGHT 2
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
         let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        let image = decoder.read_image().unwrap();
-        match image {
+        assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+        assert_eq!(decoder.dimensions().unwrap(), (2, 2));
+        assert_eq!(decoder.maxwhite, 255);
+        assert_eq!(decoder.subtype, PNMSubtype::ArbitraryMap);
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
                      0xde, 0xad, 0xbe, 0xef]),
         }
-        assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
     }
 
     #[test]
@@ -605,9 +611,11 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = [&b"P4 6 2\n"[..], &[0b01101100 as u8, 0b10110111]].concat();
         let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        let image = decoder.read_image().unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        match image {
+        assert_eq!(decoder.dimensions().unwrap(), (6, 2));
+        assert_eq!(decoder.maxwhite, 1);
+        assert_eq!(decoder.subtype, PNMSubtype::Bitmap(SampleEncoding::Binary));
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![1, 0, 0, 1, 0, 0,
@@ -621,9 +629,11 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0 1";
         let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        let image = decoder.read_image().unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        match image {
+        assert_eq!(decoder.dimensions().unwrap(), (6, 2));
+        assert_eq!(decoder.maxwhite, 1);
+        assert_eq!(decoder.subtype, PNMSubtype::Bitmap(SampleEncoding::Ascii));
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![1, 0, 0, 1, 0, 0,
@@ -638,9 +648,11 @@ ENDHDR
         let elements = (0..16).collect::<Vec<_>>();
         let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
         let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        let image = decoder.read_image().unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-        match image {
+        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        assert_eq!(decoder.maxwhite, 255);
+        assert_eq!(decoder.subtype, PNMSubtype::Graymap(SampleEncoding::Binary));
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data, elements),
         }
@@ -652,9 +664,11 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
         let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        let image = decoder.read_image().unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-        match image {
+        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        assert_eq!(decoder.maxwhite, 255);
+        assert_eq!(decoder.subtype, PNMSubtype::Graymap(SampleEncoding::Ascii));
+        match decoder.read_image().unwrap() {
             DecodingResult::U16(_) => panic!("Decoded wrong image format"),
             DecodingResult::U8(data) => assert_eq!(data,
                 (0..16).collect::<Vec<_>>()),

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -619,7 +619,7 @@ ENDHDR
     fn pbm_ascii() {
         // The data contains two rows of the image (each line is padded to the full byte). For
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
-        let pbmbinary = b"P4 6 2\n 0 1 1 0 1 1\n1 0 1 1 0 1";
+        let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0 1";
         let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
         let image = decoder.read_image().unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
@@ -628,6 +628,36 @@ ENDHDR
             DecodingResult::U8(data) => assert_eq!(data,
                 vec![1, 0, 0, 1, 0, 0,
                      0, 1, 0, 0, 1, 0,]),
+        }
+    }
+
+    #[test]
+    fn pgm_binary() {
+        // The data contains two rows of the image (each line is padded to the full byte). For
+        // comments on its format, see documentation of `impl SampleType for PbmBit`.
+        let elements = (0..16).collect::<Vec<_>>();
+        let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
+        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let image = decoder.read_image().unwrap();
+        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
+        match image {
+            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
+            DecodingResult::U8(data) => assert_eq!(data, elements),
+        }
+    }
+
+    #[test]
+    fn pgm_ascii() {
+        // The data contains two rows of the image (each line is padded to the full byte). For
+        // comments on its format, see documentation of `impl SampleType for PbmBit`.
+        let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
+        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let image = decoder.read_image().unwrap();
+        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
+        match image {
+            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
+            DecodingResult::U8(data) => assert_eq!(data,
+                (0..16).collect::<Vec<_>>()),
         }
     }
 }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -1,0 +1,302 @@
+use std::io::{Read, BufReader};
+use std::ascii::AsciiExt;
+
+use color::{ColorType};
+use image::{DecodingResult, ImageDecoder, ImageResult, ImageError};
+extern crate byteorder;
+use self::byteorder::{BigEndian, ByteOrder};
+
+enum DecodeStrategy {
+    Bytes,
+    Ascii,
+}
+
+enum TupleType {
+    RGB,
+    Grayscale,
+    Bit,
+}
+
+/// PNM decoder
+pub struct PNMDecoder<R> {
+    reader: BufReader<R>,
+    width: u32,
+    height: u32,
+    maxwhite: u32,
+    tuple: TupleType,
+    decoder: DecodeStrategy,
+}
+
+impl<R: Read> PNMDecoder<R> {
+    /// Create a new decoder that decodes from the stream ```r```
+    pub fn new(read: R) -> ImageResult<PNMDecoder<R>> {
+        let mut buf = BufReader::new(read);
+        let mut magic: [u8; 2] = [0, 0];
+        try!(buf.read_exact(&mut magic[..])); // Skip magic constant
+        if magic[0] != b'P' {
+            return Err(ImageError::FormatError("Expected magic constant for ppm, P3 or P6".to_string()));
+        }
+
+        let decoder = match magic[1] {
+            b'3' => DecodeStrategy::Ascii,
+            b'6' => DecodeStrategy::Bytes,
+            _ => return Err(ImageError::FormatError("Expected magic constant for ppm, P3 or P6".to_string())),
+        };
+
+        let width = try!(PNMDecoder::read_next_u32(&mut buf));
+        let height = try!(PNMDecoder::read_next_u32(&mut buf));
+        let maxwhite = try!(PNMDecoder::read_next_u32(&mut buf));
+
+        if !(maxwhite <= u16::max_value() as u32) {
+            return Err(ImageError::FormatError("Image maxval is not less or equal to 65535".to_string()))
+        }
+
+        Ok(PNMDecoder {
+            reader: buf,
+            width: width,
+            height: height,
+            maxwhite: maxwhite,
+            tuple: TupleType::RGB,
+            decoder: decoder,
+        })
+    }
+
+    /// Reads a string as well as a single whitespace after it, ignoring comments
+    fn read_next_string(reader: &mut BufReader<R>) -> ImageResult<String> {
+        let mut bytes = Vec::new();
+
+        // pair input bytes with a bool mask to remove comments
+        let mark_comments = reader
+            .bytes()
+            .scan(true, |partof, read| {
+                let byte = match read {
+                    Err(err) => return Some((*partof, Err(err))),
+                    Ok(byte) => byte,
+                };
+                let cur_enabled = *partof && byte != b'#';
+                let next_enabled = cur_enabled || (byte == b'\r' || byte == b'\n');
+                *partof = next_enabled;
+                return Some((cur_enabled, Ok(byte)));
+            });
+
+        for (_, byte) in mark_comments.filter(|ref e| e.0) {
+            match byte {
+                Ok(b'\t') | Ok(b'\n') | Ok(b'\x0b') | Ok(b'\x0c') | Ok(b'\r') | Ok(b' ') => {
+                    if !bytes.is_empty() {
+                        break // We're done as we already have some content
+                    }
+                },
+                Ok(byte) => {
+                    bytes.push(byte);
+                },
+                Err(_) => break,
+            }
+        }
+
+        if bytes.is_empty() {
+            return Err(ImageError::FormatError("Unexpected eof".to_string()))
+        }
+
+        if !bytes.as_slice().is_ascii() {
+            return Err(ImageError::FormatError("Non ascii character in preamble".to_string()))
+        }
+
+        String::from_utf8(bytes).map_err(|_| ImageError::FormatError("Couldn't read preamble".to_string()))
+    }
+
+    fn read_next_u32(reader: &mut BufReader<R>) -> ImageResult<u32> {
+        let s = try!(PNMDecoder::read_next_string(reader));
+        s.parse::<u32>().map_err(|_| ImageError::FormatError("Invalid number in preamble".to_string()))
+    }
+}
+
+impl<R: Read> ImageDecoder for PNMDecoder<R> {
+    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
+        Ok((self.width, self.height))
+    }
+
+    fn colortype(&mut self) -> ImageResult<ColorType> {
+        match self.tuple {
+            TupleType::Grayscale if self.maxwhite < 256 => Ok(ColorType::Gray(8)),
+            TupleType::Grayscale if self.maxwhite < 65536 => Ok(ColorType::Gray(16)),
+            TupleType::RGB if self.maxwhite < 256 => Ok(ColorType::RGB(8)),
+            TupleType::RGB if self.maxwhite < 65536 => Ok(ColorType::RGB(16)),
+            TupleType::Bit => Ok(ColorType::Gray(8)),
+            _ => Err(ImageError::FormatError("Can't determine color type".to_string()))
+        }
+    }
+
+    fn row_len(&mut self) -> ImageResult<usize> {
+        self.rowlen()
+    }
+
+    fn read_scanline(&mut self, _buf: &mut [u8]) -> ImageResult<u32> {
+        unimplemented!();
+    }
+
+    fn read_image(&mut self) -> ImageResult<DecodingResult> {
+        self.read()
+    }
+}
+
+impl<R: Read> PNMDecoder<R> {
+    fn rowlen(&self) -> ImageResult<usize> {
+        match self.tuple {
+            TupleType::Bit => Bit::bytelen(self.width, 1, 1),
+            TupleType::RGB if self.maxwhite < 256 => u8::bytelen(self.width, 1, 3),
+            TupleType::RGB if self.maxwhite < 65536 => u16::bytelen(self.width, 1, 3),
+            TupleType::Grayscale if self.maxwhite < 256 => u8::bytelen(self.width, 1, 1),
+            TupleType::Grayscale if self.maxwhite < 65536 => u16::bytelen(self.width, 1, 1),
+            _ => return Err(ImageError::FormatError("Invalid sample types for row length".to_string()))
+        }
+    }
+
+    fn read(&mut self) -> ImageResult<DecodingResult> {
+        match self.tuple {
+            TupleType::Bit => self.read_samples::<Bit>(1),
+            TupleType::RGB if self.maxwhite < 256 => self.read_samples::<u8>(3),
+            TupleType::RGB if self.maxwhite < 65536 => self.read_samples::<u16>(3),
+            TupleType::Grayscale if self.maxwhite < 256 => self.read_samples::<u8>(1),
+            TupleType::Grayscale if self.maxwhite < 65536 => self.read_samples::<u16>(1),
+            _ => return Err(ImageError::FormatError("Invalid sample types for row length".to_string()))
+        }
+    }
+
+    fn read_samples<S: SampleType>(&mut self, components: u32) -> ImageResult<DecodingResult> where
+        Vec<S::T>: Into<DecodingResult> {
+        match self.decoder {
+            DecodeStrategy::Bytes => {
+                    let bytecount = S::bytelen(self.width, self.height, components)?;
+                    let mut bytes = vec![0 as u8; bytecount];
+                    (&mut self.reader).read_exact(&mut bytes)?;
+                    let samples = S::from_bytes(&bytes, self.width, self.height, components)?;
+                    Ok(samples.into())
+                },
+            DecodeStrategy::Ascii => {
+                    let samples = self.read_ascii::<S>(components)?;
+                    Ok(samples.into())
+                }
+        }
+    }
+
+    fn read_ascii<Basic: SampleType>(&mut self, components: u32) -> ImageResult<Vec<Basic::T>> {
+        let mut buffer = Vec::new();
+        for _ in 0 .. (self.width * self.height * components) {
+            let value = self.read_ascii_sample()?;
+            let sample = Basic::from_unsigned(value)?;
+            buffer.push(sample);
+        }
+        Ok(buffer)
+    }
+
+    fn read_ascii_sample(&mut self) -> ImageResult<u32> {
+        let istoken = |v: &Result<u8, _>| match v {
+                &Err(_) => false,
+                &Ok(b'\t') | &Ok(b'\n') | &Ok(b'\x0b') | &Ok(b'\x0c') | &Ok(b'\r') | &Ok(b' ') => false,
+                _ => true,
+            };
+        let token = (&mut self.reader).bytes()
+            .skip_while(|v| !istoken(v))
+            .take_while(&istoken)
+            .collect::<Result<Vec<u8>, _>>()?;
+        if !token.is_ascii() {
+            return Err(ImageError::FormatError("Non ascii character where sample value was expected".to_string()))
+        }
+        let string = String::from_utf8(token).map_err(|_| ImageError::FormatError("Error parsing sample".to_string()))?;
+        string.parse::<u32>().map_err(|_| ImageError::FormatError("Error parsing sample value".to_string()))
+    }
+}
+
+trait SampleType {
+    type T;
+    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize>;
+    /// It is guaranteed that `bytes.len() == bytelen(width, height, samples)`
+    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>>;
+    fn from_unsigned(u32) -> ImageResult<Self::T>;
+}
+
+impl SampleType for u8 {
+    type T = u8;
+    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
+        Ok((width * height * samples) as usize)
+    }
+    fn from_bytes(bytes: &[u8], _width: u32, _height: u32, _samples: u32) -> ImageResult<Vec<Self::T>> {
+        let mut buffer = Vec::new();
+        buffer.resize(bytes.len(), 0 as u8);
+        buffer.copy_from_slice(bytes);
+        Ok(buffer)
+    }
+    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
+        if val > u8::max_value() as u32 {
+            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
+        } else {
+            Ok(val as u8)
+        }
+    }
+}
+
+impl SampleType for u16 {
+    type T = u16;
+    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
+        Ok((width * height * samples * 2) as usize)
+    }
+    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>> {
+        let mut buffer = Vec::new();
+        buffer.resize((width * height * samples) as usize, 0 as u16);
+        BigEndian::read_u16_into(bytes, &mut buffer);
+        Ok(buffer)
+    }
+    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
+        if val > u16::max_value() as u32 {
+            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
+        } else {
+            Ok(val as u16)
+        }
+    }
+}
+
+struct Bit;
+impl SampleType for Bit {
+    type T = u8;
+    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
+        let count = width * samples;
+        let linelen = (count/8) + (count % 8 == 0) as u32;
+        Ok((linelen * height) as usize)
+    }
+    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>> {
+        let mut buffer = Vec::new();
+        let linecount = width * samples;
+        buffer.resize((width * height * samples) as usize, 0 as u8);
+        for line in 0..height {
+            for samplei in 0..linecount {
+                let byteindex = (samplei/8) as usize;
+                let inindex = 7 - samplei % 8;
+                let indicator = (bytes[byteindex] >> inindex) & 0x01;
+                let bufferindex = (linecount*line + samplei) as usize;
+                buffer[bufferindex] = if indicator == 0 { 0 } else { 255 };
+            }
+        }
+        Ok(buffer)
+    }
+    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
+        if val > 1 {
+            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
+        } else if val == 1 {
+            Ok(255 as u8)
+        } else {
+            Ok(0 as u8)
+        }
+    }
+}
+
+impl Into<DecodingResult> for Vec<u8> {
+    fn into(self) -> DecodingResult {
+        DecodingResult::U8(self)
+    }
+}
+
+impl Into<DecodingResult> for Vec<u16> {
+    fn into(self) -> DecodingResult {
+        DecodingResult::U16(self)
+    }
+}

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -1,0 +1,1 @@
+pub mod decoder;

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -1,1 +1,3 @@
-pub mod decoder;
+pub use self::decoder::{PNMDecoder, PNMSubtype};
+
+mod decoder;

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -1,3 +1,9 @@
+//! Decoding of netpbm image formats (pbm, pgm, ppm and pam).
+//!
+//! The formats pbm, pgm and ppm are fully supported. The pam decoder recognizes the tuple types
+//! `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitely recognizes but rejects their `_ALPHA`
+//! variants for now as alpha color types are unsupported.
+
 pub use self::decoder::{PNMDecoder, PNMSubtype};
 
 mod decoder;

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -12,7 +12,7 @@ impl<R: Read> PPMDecoder<R> {
     pub fn new(read: R) -> ImageResult<PPMDecoder<R>> {
         let pnm = PNMDecoder::new(read)?;
         match pnm.subtype() {
-            PNMSubtype::Pixmap => {},
+            PNMSubtype::Pixmap(_) => {},
             _ => return Err(ImageError::FormatError("Expected pixmap magic constant (P3 or P6)".to_string())),
         }
         Ok(PPMDecoder(pnm))

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -1,304 +1,39 @@
 use std::io::Read;
-use std::io::BufReader;
-use std::ascii::AsciiExt;
 
 use color::{ColorType};
-use image::{DecodingResult, ImageDecoder, ImageResult, ImageError};
-extern crate byteorder;
-use self::byteorder::{BigEndian, ByteOrder};
+use image::{DecodingResult, ImageDecoder, ImageResult};
+use ::pnm::decoder::PNMDecoder;
 
-enum DecodeStrategy {
-    Bytes,
-    Ascii,
-}
-
-enum TupleType {
-    RGB,
-    Grayscale,
-    Bit,
-}
-
-/// PPM decoder
-pub struct PPMDecoder<R> {
-    reader: BufReader<R>,
-    width: u32,
-    height: u32,
-    maxwhite: u32,
-    tuple: TupleType,
-    decoder: DecodeStrategy,
-}
+/// PPM decoder, restriction pnm type to ppm
+pub struct PPMDecoder<R>(PNMDecoder<R>);
 
 impl<R: Read> PPMDecoder<R> {
-    /// Create a new decoder that decodes from the stream ```r```
+    /// Create a new pnm decoder and asserts it is ppm
     pub fn new(read: R) -> ImageResult<PPMDecoder<R>> {
-        let mut buf = BufReader::new(read);
-        let mut magic: [u8; 2] = [0, 0];
-        try!(buf.read_exact(&mut magic[..])); // Skip magic constant
-        if magic[0] != b'P' {
-            return Err(ImageError::FormatError("Expected magic constant for ppm, P3 or P6".to_string()));
-        }
-
-        let decoder = match magic[1] {
-            b'3' => DecodeStrategy::Ascii,
-            b'6' => DecodeStrategy::Bytes,
-            _ => return Err(ImageError::FormatError("Expected magic constant for ppm, P3 or P6".to_string())),
-        };
-
-        let width = try!(PPMDecoder::read_next_u32(&mut buf));
-        let height = try!(PPMDecoder::read_next_u32(&mut buf));
-        let maxwhite = try!(PPMDecoder::read_next_u32(&mut buf));
-
-        if !(maxwhite <= u16::max_value() as u32) {
-            return Err(ImageError::FormatError("Image maxval is not less or equal to 65535".to_string()))
-        }
-
-        Ok(PPMDecoder {
-            reader: buf,
-            width: width,
-            height: height,
-            maxwhite: maxwhite,
-            tuple: TupleType::RGB,
-            decoder: decoder,
-        })
-    }
-
-    /// Reads a string as well as a single whitespace after it, ignoring comments
-    fn read_next_string(reader: &mut BufReader<R>) -> ImageResult<String> {
-        let mut bytes = Vec::new();
-
-        // pair input bytes with a bool mask to remove comments
-        let mark_comments = reader
-            .bytes()
-            .scan(true, |partof, read| {
-                let byte = match read {
-                    Err(err) => return Some((*partof, Err(err))),
-                    Ok(byte) => byte,
-                };
-                let cur_enabled = *partof && byte != b'#';
-                let next_enabled = cur_enabled || (byte == b'\r' || byte == b'\n');
-                *partof = next_enabled;
-                return Some((cur_enabled, Ok(byte)));
-            });
-
-        for (_, byte) in mark_comments.filter(|ref e| e.0) {
-            match byte {
-                Ok(b'\t') | Ok(b'\n') | Ok(b'\x0b') | Ok(b'\x0c') | Ok(b'\r') | Ok(b' ') => {
-                    if !bytes.is_empty() {
-                        break // We're done as we already have some content
-                    }
-                },
-                Ok(byte) => {
-                    bytes.push(byte);
-                },
-                Err(_) => break,
-            }
-        }
-
-        if bytes.is_empty() {
-            return Err(ImageError::FormatError("Unexpected eof".to_string()))
-        }
-
-        if !bytes.as_slice().is_ascii() {
-            return Err(ImageError::FormatError("Non ascii character in preamble".to_string()))
-        }
-
-        String::from_utf8(bytes).map_err(|_| ImageError::FormatError("Couldn't read preamble".to_string()))
-    }
-
-    fn read_next_u32(reader: &mut BufReader<R>) -> ImageResult<u32> {
-        let s = try!(PPMDecoder::read_next_string(reader));
-        s.parse::<u32>().map_err(|_| ImageError::FormatError("Invalid number in preamble".to_string()))
+        let pnm = PNMDecoder::new(read)?;
+        Ok(PPMDecoder(pnm))
     }
 }
 
 impl<R: Read> ImageDecoder for PPMDecoder<R> {
     fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        Ok((self.width, self.height))
+        self.0.dimensions()
     }
 
     fn colortype(&mut self) -> ImageResult<ColorType> {
-        match self.tuple {
-            TupleType::Grayscale if self.maxwhite < 256 => Ok(ColorType::Gray(8)),
-            TupleType::Grayscale if self.maxwhite < 65536 => Ok(ColorType::Gray(16)),
-            TupleType::RGB if self.maxwhite < 256 => Ok(ColorType::RGB(8)),
-            TupleType::RGB if self.maxwhite < 65536 => Ok(ColorType::RGB(16)),
-            TupleType::Bit => Ok(ColorType::Gray(8)),
-            _ => Err(ImageError::FormatError("Can't determine color type".to_string()))
-        }
+        self.0.colortype()
     }
 
     fn row_len(&mut self) -> ImageResult<usize> {
-        self.rowlen()
+        self.0.row_len()
     }
 
-    fn read_scanline(&mut self, _buf: &mut [u8]) -> ImageResult<u32> {
-        unimplemented!();
+    fn read_scanline(&mut self, mut buf: &mut [u8]) -> ImageResult<u32> {
+        self.0.read_scanline(&mut buf)
     }
 
     fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        self.read()
-    }
-}
-
-impl<R: Read> PPMDecoder<R> {
-    fn rowlen(&self) -> ImageResult<usize> {
-        match self.tuple {
-            TupleType::Bit => Bit::bytelen(self.width, 1, 1),
-            TupleType::RGB if self.maxwhite < 256 => u8::bytelen(self.width, 1, 3),
-            TupleType::RGB if self.maxwhite < 65536 => u16::bytelen(self.width, 1, 3),
-            TupleType::Grayscale if self.maxwhite < 256 => u8::bytelen(self.width, 1, 1),
-            TupleType::Grayscale if self.maxwhite < 65536 => u16::bytelen(self.width, 1, 1),
-            _ => return Err(ImageError::FormatError("Invalid sample types for row length".to_string()))
-        }
-    }
-
-    fn read(&mut self) -> ImageResult<DecodingResult> {
-        match self.tuple {
-            TupleType::Bit => self.read_samples::<Bit>(1),
-            TupleType::RGB if self.maxwhite < 256 => self.read_samples::<u8>(3),
-            TupleType::RGB if self.maxwhite < 65536 => self.read_samples::<u16>(3),
-            TupleType::Grayscale if self.maxwhite < 256 => self.read_samples::<u8>(1),
-            TupleType::Grayscale if self.maxwhite < 65536 => self.read_samples::<u16>(1),
-            _ => return Err(ImageError::FormatError("Invalid sample types for row length".to_string()))
-        }
-    }
-
-    fn read_samples<S: SampleType>(&mut self, components: u32) -> ImageResult<DecodingResult> where
-        Vec<S::T>: Into<DecodingResult> {
-        match self.decoder {
-            DecodeStrategy::Bytes => {
-                    let bytecount = S::bytelen(self.width, self.height, components)?;
-                    let mut bytes = vec![0 as u8; bytecount];
-                    (&mut self.reader).read_exact(&mut bytes)?;
-                    let samples = S::from_bytes(&bytes, self.width, self.height, components)?;
-                    Ok(samples.into())
-                },
-            DecodeStrategy::Ascii => {
-                    let samples = self.read_ascii::<S>(components)?;
-                    Ok(samples.into())
-                }
-        }
-    }
-
-    fn read_ascii<Basic: SampleType>(&mut self, components: u32) -> ImageResult<Vec<Basic::T>> {
-        let mut buffer = Vec::new();
-        for _ in 0 .. (self.width * self.height * components) {
-            let value = self.read_ascii_sample()?;
-            let sample = Basic::from_unsigned(value)?;
-            buffer.push(sample);
-        }
-        Ok(buffer)
-    }
-
-    fn read_ascii_sample(&mut self) -> ImageResult<u32> {
-        let istoken = |v: &Result<u8, _>| match v {
-                &Err(_) => false,
-                &Ok(b'\t') | &Ok(b'\n') | &Ok(b'\x0b') | &Ok(b'\x0c') | &Ok(b'\r') | &Ok(b' ') => false,
-                _ => true,
-            };
-        let token = (&mut self.reader).bytes()
-            .skip_while(|v| !istoken(v))
-            .take_while(&istoken)
-            .collect::<Result<Vec<u8>, _>>()?;
-        if !token.is_ascii() {
-            return Err(ImageError::FormatError("Non ascii character where sample value was expected".to_string()))
-        }
-        let string = String::from_utf8(token).map_err(|_| ImageError::FormatError("Error parsing sample".to_string()))?;
-        string.parse::<u32>().map_err(|_| ImageError::FormatError("Error parsing sample value".to_string()))
-    }
-}
-
-trait SampleType {
-    type T;
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize>;
-    /// It is guaranteed that `bytes.len() == bytelen(width, height, samples)`
-    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>>;
-    fn from_unsigned(u32) -> ImageResult<Self::T>;
-}
-
-impl SampleType for u8 {
-    type T = u8;
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        Ok((width * height * samples) as usize)
-    }
-    fn from_bytes(bytes: &[u8], _width: u32, _height: u32, _samples: u32) -> ImageResult<Vec<Self::T>> {
-        let mut buffer = Vec::new();
-        buffer.resize(bytes.len(), 0 as u8);
-        buffer.copy_from_slice(bytes);
-        Ok(buffer)
-    }
-    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
-        if val > u8::max_value() as u32 {
-            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
-        } else {
-            Ok(val as u8)
-        }
-    }
-}
-
-impl SampleType for u16 {
-    type T = u16;
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        Ok((width * height * samples * 2) as usize)
-    }
-    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>> {
-        let mut buffer = Vec::new();
-        buffer.resize((width * height * samples) as usize, 0 as u16);
-        BigEndian::read_u16_into(bytes, &mut buffer);
-        Ok(buffer)
-    }
-    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
-        if val > u16::max_value() as u32 {
-            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
-        } else {
-            Ok(val as u16)
-        }
-    }
-}
-
-struct Bit;
-impl SampleType for Bit {
-    type T = u8;
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        let count = width * samples;
-        let linelen = (count/8) + (count % 8 == 0) as u32;
-        Ok((linelen * height) as usize)
-    }
-    fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32) -> ImageResult<Vec<Self::T>> {
-        let mut buffer = Vec::new();
-        let linecount = width * samples;
-        buffer.resize((width * height * samples) as usize, 0 as u8);
-        for line in 0..height {
-            for samplei in 0..linecount {
-                let byteindex = (samplei/8) as usize;
-                let inindex = 7 - samplei % 8;
-                let indicator = (bytes[byteindex] >> inindex) & 0x01;
-                let bufferindex = (linecount*line + samplei) as usize;
-                buffer[bufferindex] = if indicator == 0 { 0 } else { 255 };
-            }
-        }
-        Ok(buffer)
-    }
-    fn from_unsigned(val: u32) -> ImageResult<Self::T> {
-        if val > 1 {
-            Err(ImageError::FormatError("Sample value outside of bounds".to_string()))
-        } else if val == 1 {
-            Ok(255 as u8)
-        } else {
-            Ok(0 as u8)
-        }
-    }
-}
-
-impl Into<DecodingResult> for Vec<u8> {
-    fn into(self) -> DecodingResult {
-        DecodingResult::U8(self)
-    }
-}
-
-impl Into<DecodingResult> for Vec<u16> {
-    fn into(self) -> DecodingResult {
-        DecodingResult::U16(self)
+        self.0.read_image()
     }
 }
 

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -1,3 +1,4 @@
+#![deprecated(since="0.17.0", note="Use `pnm::PNMDecoder` instead, check the subtype if necessary")]
 use std::io::Read;
 
 use color::{ColorType};

--- a/src/ppm/decoder.rs
+++ b/src/ppm/decoder.rs
@@ -1,8 +1,8 @@
 use std::io::Read;
 
 use color::{ColorType};
-use image::{DecodingResult, ImageDecoder, ImageResult};
-use ::pnm::decoder::PNMDecoder;
+use image::{DecodingResult, ImageDecoder, ImageResult, ImageError};
+use pnm::{PNMDecoder, PNMSubtype};
 
 /// PPM decoder, restriction pnm type to ppm
 pub struct PPMDecoder<R>(PNMDecoder<R>);
@@ -11,6 +11,10 @@ impl<R: Read> PPMDecoder<R> {
     /// Create a new pnm decoder and asserts it is ppm
     pub fn new(read: R) -> ImageResult<PPMDecoder<R>> {
         let pnm = PNMDecoder::new(read)?;
+        match pnm.subtype() {
+            PNMSubtype::Pixmap => {},
+            _ => return Err(ImageError::FormatError("Expected pixmap magic constant (P3 or P6)".to_string())),
+        }
         Ok(PPMDecoder(pnm))
     }
 }


### PR DESCRIPTION
Adds decoders and format recognition for the following formats from the netbpm package:
[Portable Bit Map][pbm], [Portable Gray Map][pgm] and [Portable Arbitrary Map][pam]

[pbm]: http://netpbm.sourceforge.net/doc/pbm.html
[pgm]: http://netpbm.sourceforge.net/doc/pgm.html
[pam]: http://netpbm.sourceforge.net/doc/pam.html

Details
---------
The pam format decoder recognizes the tuple types `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitely recognizes but rejects their `_ALPHA` variants (support for these might come in another patch).

Tests for the new formats are not yet included but will arrive in the next week, this should stay open until then.

This should deprecate the pam module, not yet part of this pull request. In case it is desired to explicitely test for the `ppm` format instead, the decoder class offers a method to query the specific image subtype after the header has been read and a wrapper for `ppm` specificially has been put into the place of the old decoder.

Related Issues
---------
This closes #664 
