### PR TITLE
bump byteorder requirement to 1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "image"
 path = "./src/lib.rs"
 
 [dependencies]
-byteorder = "1.0.0"
+byteorder = "1.2.1"
 num-iter = "0.1.32"
 num-rational = { version = "0.1.32", default-features = false }
 num-traits = "0.1.32"


### PR DESCRIPTION
Build failes because BigEndian::read_u16_into is used in pnm/decoder,
and is not available in byteorder 1.0.0.