### PR TITLE
Allow using GenericImage trait object.

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -218,7 +218,7 @@ pub trait ImageDecoder: Sized {
 
 
 /// Immutable pixel iterator
-pub struct Pixels<'a, I: 'a> {
+pub struct Pixels<'a, I: ?Sized + 'a> {
     image:  &'a I,
     x:      u32,
     y:      u32,
@@ -251,7 +251,7 @@ impl<'a, I: GenericImage> Iterator for Pixels<'a, I> {
 /// Mutable pixel iterator
 ///
 /// DEPRECATED: It is currently not possible to create a safe iterator for this in Rust. You have to use an iterator over the image buffer instead.
-pub struct MutPixels<'a, I: 'a> {
+pub struct MutPixels<'a, I: ?Sized + 'a> {
     image:  &'a mut I,
     x:      u32,
     y:      u32,
@@ -292,7 +292,7 @@ impl<'a, I: GenericImage + 'a> Iterator for MutPixels<'a, I>
 }
 
 /// A trait for manipulating images.
-pub trait GenericImage: Sized {
+pub trait GenericImage {
     /// The type of pixel.
     type Pixel: Pixel;
 
@@ -433,7 +433,7 @@ pub trait GenericImage: Sized {
 }
 
 /// A View into another image
-pub struct SubImage <'a, I: 'a> {
+pub struct SubImage <'a, I: ?Sized + 'a> {
     image:   &'a mut I,
     xoffset: u32,
     yoffset: u32,
@@ -442,7 +442,7 @@ pub struct SubImage <'a, I: 'a> {
 }
 
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
-impl<'a, I: GenericImage + 'static> SubImage<'a, I>
+impl<'a, I: ?Sized + GenericImage + 'static> SubImage<'a, I>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 
@@ -487,7 +487,7 @@ impl<'a, I: GenericImage + 'static> SubImage<'a, I>
 
 #[allow(deprecated)]
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-impl<'a, I: GenericImage + 'static> GenericImage for SubImage<'a, I>
+impl<'a, I: ?Sized + GenericImage + 'static> GenericImage for SubImage<'a, I>
     where I::Pixel: 'static,
           <I::Pixel as Pixel>::Subpixel: 'static {
 
@@ -525,6 +525,11 @@ mod tests {
     use super::GenericImage;
     use buffer::ImageBuffer;
     use color::{Rgba};
+
+    #[test]
+    fn test_image_trait_object() {
+        let img = Box::new(ImageBuffer::new(1, 1)) as Box<GenericImage<Pixel=Rgba>>;
+    }
 
     #[test]
     /// Test that alpha blending works as expected


### PR DESCRIPTION
This removes the `Sized` bound from `GenericImage`, and adds the nondefault `?Sized` bound to some structs so we can use `dyn GenericImage<Pixel=Rgba>`.