### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -662,7 +662,7 @@ fn save_buffer_impl(path: &Path, buf: &[u8], width: u32, height: u32, color: col
 
 /// Create a new image from a Reader
 pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
-    #[allow(deprecated, unreachable_patterns)]
+    #[allow(deprecated, unreachable_patterns)] // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "png_codec")]
         image::ImageFormat::PNG  => decoder_to_image(png::PNGDecoder::new(r)),
@@ -686,7 +686,6 @@ pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIm
         image::ImageFormat::PPM => decoder_to_image(try!(ppm::PPMDecoder::new(BufReader::new(r)))),
         #[cfg(feature = "pnm")]
         image::ImageFormat::PNM => decoder_to_image(try!(pnm::PNMDecoder::new(BufReader::new(r)))),
-        // This should be unreachable, but is kept in case of bogus feature combinations.
         _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -401,6 +401,7 @@ impl DynamicImage {
         let (width, height) = self.dimensions();
         let color = self.color();
 
+        #[allow(deprecated)]
         match format {
             #[cfg(feature = "png_codec")]
             image::ImageFormat::PNG  => {
@@ -608,7 +609,10 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
         "pbm" |
         "pam" |
         "pgm" => image::ImageFormat::PNM,
-        "ppm" => image::ImageFormat::PPM,
+        "ppm" => {
+            #[allow(deprecated)]
+            image::ImageFormat::PPM
+        }
         format => return Err(image::ImageError::UnsupportedError(format!(
             "Image format image/{:?} is not supported.",
             format
@@ -658,6 +662,7 @@ fn save_buffer_impl(path: &Path, buf: &[u8], width: u32, height: u32, color: col
 
 /// Create a new image from a Reader
 pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+    #[allow(deprecated)]
     match format {
         #[cfg(feature = "png_codec")]
         image::ImageFormat::PNG  => decoder_to_image(png::PNGDecoder::new(r)),
@@ -701,7 +706,9 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
     (b"P3", ImageFormat::PNM),
     (b"P4", ImageFormat::PNM),
     (b"P5", ImageFormat::PNM),
-    (b"P6", ImageFormat::PPM),
+    (b"P6",
+     #[allow(deprecated)]
+     ImageFormat::PPM),
     (b"P7", ImageFormat::PNM),
 ];
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -662,7 +662,7 @@ fn save_buffer_impl(path: &Path, buf: &[u8], width: u32, height: u32, color: col
 
 /// Create a new image from a Reader
 pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
-    #[allow(deprecated)]
+    #[allow(deprecated, unreachable_patterns)]
     match format {
         #[cfg(feature = "png_codec")]
         image::ImageFormat::PNG  => decoder_to_image(png::PNGDecoder::new(r)),
@@ -686,6 +686,7 @@ pub fn load<R: BufRead+Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIm
         image::ImageFormat::PPM => decoder_to_image(try!(ppm::PPMDecoder::new(BufReader::new(r)))),
         #[cfg(feature = "pnm")]
         image::ImageFormat::PNM => decoder_to_image(try!(pnm::PNMDecoder::new(BufReader::new(r)))),
+        // This should be unreachable, but is kept in case of bogus feature combinations.
         _ => Err(image::ImageError::UnsupportedError(format!("A decoder for {:?} is not available.", format))),
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -3,6 +3,7 @@ use std::io::{Write, Seek, BufRead, BufReader, BufWriter};
 use std::path::Path;
 use std::fs::File;
 use std::iter;
+#[allow(unused)] // AsciiExt not needed for rust 1.23 and up.
 use std::ascii::AsciiExt;
 use num_iter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,10 +62,11 @@ pub use image::ImageFormat::{
     JPEG,
     GIF,
     WEBP,
-    PPM,
     BMP,
     ICO
 };
+#[allow(deprecated)]
+pub use image::ImageFormat::PPM;
 
 pub use buffer::{
     Pixel,

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, BufRead, BufReader};
+#[allow(unused)] // AsciiExt not needed for rust 1.23 and up.
 use std::ascii::AsciiExt;
 
 use color::{ColorType};

--- a/src/ppm/mod.rs
+++ b/src/ppm/mod.rs
@@ -1,6 +1,7 @@
 //! Encoding of portable pixmap Images
 
 pub use self::encoder::PPMEncoder as PPMEncoder;
+#[allow(deprecated)]
 pub use self::decoder::PPMDecoder as PPMDecoder;
 
 mod encoder;
@@ -13,6 +14,7 @@ mod test {
 
     #[test]
     fn test_roundtrip_ppm() {
+        #![allow(deprecated)]
         // 3x3 image that tries all the 0/255 RGB combinations
         let buf: [u8; 27] = [
               0,   0,   0,
@@ -51,6 +53,7 @@ mod test {
 
     #[test]
     fn test_roundtrip_ppm_16bit() {
+        #![allow(deprecated)]
         // 3x3 image that tries all the 0/65535 RGB combinations plus a few more values
         // that check for big-endian conversion correctness
         let buf: [u16; 27] = [


### PR DESCRIPTION
Fix some annoying compiler warnings.

I want to improve on image scaling, but got too annoyed by compiler warnings (mainly about deprecated ppm support) while experimenting (I hope to be able to submit a PR for image scaling soonish).