### PR TITLE
A way to expose options when saving files

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -38,6 +38,7 @@ use image:: {
     ImageDecoder,
     ImageResult,
     ImageFormat,
+    ImageOutputFormat,
 };
 
 use image::DecodingResult::{U8};
@@ -395,21 +396,22 @@ impl DynamicImage {
     }
 
     /// Encode this image and write it to ```w```
-    pub fn save<W: Write>(&self, w: &mut W, format: ImageFormat) -> ImageResult<()> {
+    pub fn save<W: Write, F: Into<ImageOutputFormat>>(&self, w: &mut W, format: F) -> ImageResult<()> {
         let bytes = self.raw_pixels();
         let (width, height) = self.dimensions();
         let color = self.color();
+        let format = format.into();
 
         match format {
             #[cfg(feature = "png_codec")]
-            image::ImageFormat::PNG  => {
+            image::ImageOutputFormat::PNG  => {
                 let p = png::PNGEncoder::new(w);
 
                 try!(p.encode(&bytes, width, height, color));
                 Ok(())
             }
             #[cfg(feature = "ppm")]
-            image::ImageFormat::PPM  => {
+            image::ImageOutputFormat::PPM  => {
                 let mut p = ppm::PPMEncoder::new(w);
 
                 try!(p.encode(&bytes, width, height, color));
@@ -417,15 +419,15 @@ impl DynamicImage {
             }
 
             #[cfg(feature = "jpeg")]
-            image::ImageFormat::JPEG => {
-                let mut j = jpeg::JPEGEncoder::new(w);
+            image::ImageOutputFormat::JPEG(quality) => {
+                let mut j = jpeg::JPEGEncoder::new_with_quality(w, quality);
 
                 try!(j.encode(&bytes, width, height, color));
                 Ok(())
             }
 
             #[cfg(feature = "gif_codec")]
-            image::ImageFormat::GIF => {
+            image::ImageOutputFormat::GIF => {
                 let g = gif::Encoder::new(w);
 
                 try!(g.encode(gif::Frame::from_rgba(
@@ -437,7 +439,7 @@ impl DynamicImage {
             }
 
             #[cfg(feature = "ico")]
-            image::ImageFormat::ICO => {
+            image::ImageOutputFormat::ICO => {
                 let i = ico::ICOEncoder::new(w);
 
                 try!(i.encode(&bytes, width, height, color));
@@ -445,15 +447,13 @@ impl DynamicImage {
             }
 
             #[cfg(feature = "bmp")]
-            image::ImageFormat::BMP => {
+            image::ImageOutputFormat::BMP => {
                 let mut b = bmp::BMPEncoder::new(w);
                 try!(b.encode(&bytes, width, height, color));
                 Ok(())
             }
 
-            _ => Err(image::ImageError::UnsupportedError(
-                     format!("An encoder for {:?} is not available.", format))
-                 ),
+            image::ImageOutputFormat::Unsupported(msg) => Err(image::ImageError::UnsupportedError(msg)),
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -141,6 +141,61 @@ pub enum ImageFormat {
     HDR,
 }
 
+/// An enumeration of supported image formats for encoding.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ImageOutputFormat {
+    #[cfg(feature = "png_codec")]
+    /// An Image in PNG Format
+    PNG,
+
+    #[cfg(feature = "jpeg")]
+    /// An Image in JPEG Format with specified quality
+    JPEG(u8),
+
+    #[cfg(feature = "ppm")]
+    /// An Image in PPM Format
+    #[deprecated(since="0.17.0", note="Use the more general `PNM`")]
+    PPM,
+
+    #[cfg(feature = "gif_codec")]
+    /// An Image in GIF Format
+    GIF,
+
+    #[cfg(feature = "ico")]
+    /// An Image in ICO Format
+    ICO,
+
+    #[cfg(feature = "bmp")]
+    /// An Image in BMP Format
+    BMP,
+
+    /// A value for signalling an error: An unsupported format was requested
+    // Note: When TryFrom is stabilized, this value should not be needed, and
+    // a TryInto<ImageOutputFormat> should be used instead of an Into<ImageOutputFormat>.
+    Unsupported(String),
+}
+
+impl From<ImageFormat> for ImageOutputFormat {
+    fn from(fmt: ImageFormat) -> Self {
+        match fmt {
+            #[cfg(feature = "png_codec")]
+            ImageFormat::PNG => ImageOutputFormat::PNG,
+            #[cfg(feature = "jpeg")]
+            ImageFormat::JPEG => ImageOutputFormat::JPEG(75),
+            #[cfg(feature = "ppm")]
+            ImageFormat::PPM => ImageOutputFormat::PPM,
+            #[cfg(feature = "gif_codec")]
+            ImageFormat::GIF => ImageOutputFormat::GIF,
+            #[cfg(feature = "ico")]
+            ImageFormat::ICO => ImageOutputFormat::ICO,
+            #[cfg(feature = "bmp")]
+            ImageFormat::BMP => ImageOutputFormat::BMP,
+
+            f => ImageOutputFormat::Unsupported(format!("Image format {:?} not supported for encoding.", f)),
+        }
+    }
+}
+
 /// The trait that all decoders implement
 pub trait ImageDecoder: Sized {
     /// Returns a tuple containing the width and height of the image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use image::ImageFormat::{
     BMP,
     ICO
 };
+pub use image::ImageOutputFormat;
 
 pub use buffer::{
     Pixel,

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -1,0 +1,25 @@
+//! Test saving "default" and specific quality jpeg.
+extern crate image;
+
+use image::{ImageOutputFormat, JPEG};
+
+#[test]
+fn jqeg_qualitys() {
+    let img = image::open("tests/images/tiff/testsuite/lenna.tiff").unwrap();
+
+    let mut default = vec![];
+    img.save(&mut default, JPEG).unwrap();
+    assert_eq!(&[255, 216], &default[..2]);
+
+    let mut small = vec![];
+    img.save(&mut small, ImageOutputFormat::JPEG(10)).unwrap();
+    assert_eq!(&[255, 216], &small[..2]);
+
+    assert!(small.len() < default.len());
+
+    let mut large = vec![];
+    img.save(&mut large, ImageOutputFormat::JPEG(99)).unwrap();
+    assert_eq!(&[255, 216], &large[..2]);
+
+    assert!(large.len() > default.len());
+}


### PR DESCRIPTION
Provide a way to provide format-specific options (with default values) when saving an image.  Jpeg quality is used as an example.

This closes #581 in a different way than #584.