### PR TITLE
Fix issue where resizing an image doesn't always give an exact width/height

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ optional = true
 [dev-dependencies]
 num-complex = "0.1.32"
 glob = "0.2.10"
+quickcheck = "0.6.2"
 
 [features]
 default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt"]

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -725,6 +725,13 @@ pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
     )
 }
 
+/// Calculates the width and height an image should be resized to.
+/// This preserves aspect ratio, and based on the `fill` parameter
+/// will either fill the dimensions to fit inside the smaller constraint
+/// (will overflow the specified bounds on one axis to preserve
+/// aspect ratio), or will shrink so that both dimensions are
+/// completely contained with in the given `width` and `height`,
+/// with empty space on one axis.
 fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u32, fill: bool) -> (u32, u32) {
     let ratio  = width as u64 * nheight as u64;
     let nratio = nwidth as u64 * height as u64;

--- a/src/image.rs
+++ b/src/image.rs
@@ -10,6 +10,7 @@ use buffer::{ImageBuffer, Pixel};
 use animation::{Frame, Frames};
 use dynimage::decoder_to_image;
 
+#[cfg(feature = "pnm")]
 use pnm::PNMSubtype;
 
 /// An enumeration of Image errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ extern crate enum_primitive;
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
 
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+
 use std::io::Write;
 
 pub use color::ColorType::{


### PR DESCRIPTION
Also refactors out common resizing logic from `resize` and `resize_to_fill`

It seems that this was due to insufficient precision in the `f32` type which was causing rounding errors in some cases. `f64` seems to have enough precision to handle this accurately, at least in the cases I tested.

Closes #667