### PR TITLE
Added jpeg_no_rayon feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
       - FEATURES=''
       - FEATURES='gif_codec'
       - FEATURES='jpeg'
+      - FEATURES='jpeg_no_rayon'
       - FEATURES='png_codec'
       - FEATURES='ppm'
       - FEATURES='tga'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ optional = true
 [dependencies.jpeg-decoder]
 version = "0.1"
 optional = true
+default-features = false
 
 [dependencies.png]
 version = "0.11"
@@ -56,7 +57,7 @@ default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "ppm", "tga", "tiff",
 
 gif_codec = ["gif"]
 ico = ["bmp", "png_codec"]
-jpeg = ["jpeg-decoder"]
+jpeg = ["jpeg-decoder/rayon"]
 png_codec = ["png"]
 pnm = []
 ppm = ["pnm"]
@@ -65,5 +66,6 @@ tiff = []
 webp = []
 bmp = []
 hdr = ["scoped_threadpool"]
+jpeg_no_rayon = ["jpeg-decoder"]
 
 benchmarks = []


### PR DESCRIPTION
It is an inverse approach of pr https://github.com/PistonDevelopers/image/pull/724 to allow no rayon dependency and without performance drop on default usage. 

The reason to this change is because rayon is not working on wasm target  right now, we should allow user to bypass it.