### PR TITLE
Fix off-by-one grayscale JPEG encoding

### DIFF
--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -663,7 +663,7 @@ fn copy_blocks_gray(source: &[u8],
 
         for x in 0usize..8 {
             let xstride = x0 * bpp + x * bpp;
-            gb[y * 8 + x] = value_at(source, ystride + xstride + 1);
+            gb[y * 8 + x] = value_at(source, ystride + xstride + 0);
         }
     }
 }


### PR DESCRIPTION
Will push a regression test for this tomorrow, since it looks like JPEG grayscale encoding may not be covered by tests.

Closes #735.