### PR TITLE
Avoid panic when blending two pixels with zero alpha.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -377,7 +377,11 @@ impl<T: Primitive> Blend for LumaA<T> {
         let (bg_luma, bg_a) = (bg_luma.to_f32().unwrap() / max_t, bg_a.to_f32().unwrap() / max_t);
         let (fg_luma, fg_a) = (fg_luma.to_f32().unwrap() / max_t, fg_a.to_f32().unwrap() / max_t);
 
-        let alpha_final = bg_a + fg_a - bg_a * fg_a;
+        let mut alpha_final = bg_a + fg_a - bg_a * fg_a;
+        if 0.0 == alpha_final {
+            alpha_final = 1.0;
+        }
+
         let bg_luma_a = bg_luma * bg_a;
         let fg_luma_a = fg_luma * fg_a;
 
@@ -410,7 +414,10 @@ impl<T: Primitive> Blend for Rgba<T> {
         let (fg_r, fg_g, fg_b, fg_a) = (fg_r.to_f32().unwrap() / max_t, fg_g.to_f32().unwrap() / max_t, fg_b.to_f32().unwrap() / max_t, fg_a.to_f32().unwrap() / max_t);
 
         // Work out what the final alpha level will be
-        let alpha_final = bg_a + fg_a - bg_a * fg_a;
+        let mut alpha_final = bg_a + fg_a - bg_a * fg_a;
+        if 0.0 == alpha_final {
+            alpha_final = 1.0;
+        }
 
         // We premultiply our channels bu their alpha, as this makes it easier to calculate
         let (bg_r_a, bg_g_a, bg_b_a) = (bg_r * bg_a, bg_g * bg_a, bg_b * bg_a);


### PR DESCRIPTION
I ran into a situation where trying to `overlay` two rgba images led to a panic.
The root cause was a division by zero.
Here's a minimal reproducible example program run against image = "0.18.0":

```rust
extern crate image;
use image::{ImageBuffer, Rgba, RgbaImage};
use image::imageops::overlay;
fn main() {
    let mut a: RgbaImage = ImageBuffer::new(1, 1);
    a.put_pixel(0, 0, Rgba([0, 0, 0, 0]));

    let mut b: RgbaImage = ImageBuffer::new(1, 1);
    b.put_pixel(0, 0, Rgba([0, 0, 0, 0]));

    overlay(&mut a, &b, 0, 0);
}
```

I don't have a ton of graphics experience, so I'm not sure if there's a "correct" way to blend two completely transparent pixels in terms of retaining the color components.
This patch just uses the blended colors and leaves alpha at zero.

This patch is the simplest thing I could think of to fix, but I'd be happy to change to something more idiomatic (`num::CheckedDiv` trait and explicit handling of the None condition?)

