### PR TITLE
Make save() function consistant 

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -415,7 +415,7 @@ impl DynamicImage {
     }
 
     /// Encode this image and write it to ```w```
-    pub fn write<W: Write, F: Into<ImageOutputFormat>>(&self, w: &mut W, format: F) -> ImageResult<()> {
+    pub fn write_to<W: Write, F: Into<ImageOutputFormat>>(&self, w: &mut W, format: F) -> ImageResult<()> {
         let bytes = self.raw_pixels();
         let (width, height) = self.dimensions();
         let color = self.color();

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -415,7 +415,7 @@ impl DynamicImage {
     }
 
     /// Encode this image and write it to ```w```
-    pub fn save<W: Write, F: Into<ImageOutputFormat>>(&self, w: &mut W, format: F) -> ImageResult<()> {
+    pub fn write<W: Write, F: Into<ImageOutputFormat>>(&self, w: &mut W, format: F) -> ImageResult<()> {
         let bytes = self.raw_pixels();
         let (width, height) = self.dimensions();
         let color = self.color();
@@ -474,6 +474,15 @@ impl DynamicImage {
 
             image::ImageOutputFormat::Unsupported(msg) => Err(image::ImageError::UnsupportedError(msg)),
         }
+    }
+
+    /// Saves the buffer to a file at the path specified.
+    ///
+    /// The image format is derived from the file extension.
+    pub fn save<Q>(&self, path: Q) -> io::Result<()> where Q: AsRef<Path> {
+        dynamic_map!(*self, ref p -> {
+            p.save(path)
+        })
     }
 }
 


### PR DESCRIPTION
This PR makes the two `save` functions for `DynamicImage` and `ImageBuffer` the same and renames the old `DynamicImage` `save` to be ~`write`~ `write_to` instead.

This fixes #742. 