### PR TITLE
Let broken builds be marked as failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ env:
       - FEATURES='hdr'
 script:
     - if [ -z "$FEATURES" ]; then
-        cargo build -v;
-        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi;
+        cargo build -v &&
+        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi &&
         cargo doc -v;
       else
-        cargo build -v --no-default-features --features "$FEATURES";
-        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi;
+        cargo build -v --no-default-features --features "$FEATURES" &&
+        if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi &&
         cargo doc -v;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script:
       else
         cargo build -v --no-default-features --features "$FEATURES" &&
         if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi &&
-        cargo doc -v;
+        cargo doc -v --no-default-features --features "$FEATURES";
       fi

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -114,6 +114,7 @@ fn check_references() {
 	})
 }
 
+#[cfg(feature = "hdr")]
 #[test]
 fn check_hdr_references() {
     let mut ref_path: PathBuf = BASE_PATH.iter().collect();

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -33,6 +33,7 @@ where F: Fn(&PathBuf, PathBuf, &str) {
 	}
 }
 
+#[cfg(feature = "png")]
 #[test]
 fn render_images() {
 	process_images(IMAGE_DIR, None, |base, path, decoder| {

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -1,4 +1,5 @@
 //! Test saving "default" and specific quality jpeg.
+#![cfg(feature = "jpeg")]
 extern crate image;
 
 use image::{ImageOutputFormat, JPEG};

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -1,5 +1,5 @@
 //! Test saving "default" and specific quality jpeg.
-#![cfg(feature = "jpeg")]
+#![cfg(all(feature = "jpeg", feature = "tiff"))]
 extern crate image;
 
 use image::{ImageOutputFormat, JPEG};


### PR DESCRIPTION
The problem is discovered and discussed in #753.

The way each build was make in three steps hid failures in the two earlier steps behind success in the last step.  Use shell `&&` rather than `;` in `.travis.yml` to break the build directly if one step fails.

I believe this is working properly now.

- [x] see a green build after changing `.travis.yml`.
- [x] introduce an error and see that properly failing a build
- [x] fix the error and see the build green again
