### PR TITLE
change out of date examples and tests to use write_to instead of save

### DIFF
--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -47,5 +47,5 @@ fn main() {
     let fout = &mut File::create("fractal.png").unwrap();
 
     // We must indicate the image's color type and what format to save as
-    image::ImageLuma8(imgbuf).save(fout, image::PNG).unwrap();
+    image::ImageLuma8(imgbuf).write_to(fout, image::PNG).unwrap();
 }

--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -27,5 +27,5 @@ fn main() {
     let fout = &mut File::create(&Path::new(&format!("{}.png", file))).unwrap();
 
     // Write the contents of this image to the Writer in PNG format.
-    im.save(fout, image::PNG).unwrap();
+    im.write_to(fout, image::PNG).unwrap();
 }

--- a/examples/scaledown/main.rs
+++ b/examples/scaledown/main.rs
@@ -38,7 +38,7 @@ fn main() {
         let scaled = img.resize(400, 400, filter);
         println!("Scaled by {} in {}", name, Elapsed::from(&timer));
         let mut output = File::create(&format!("test-{}.png", name)).unwrap();
-        scaled.save(&mut output, PNG).unwrap();
+        scaled.write_to(&mut output, PNG).unwrap();
     }
 
     for size in &[20_u32, 40, 100, 200, 400] {
@@ -47,6 +47,6 @@ fn main() {
         println!("Thumbnailed to {} in {}", size, Elapsed::from(&timer));
         let mut output =
             File::create(format!("test-thumb{}.png", size)).unwrap();
-        scaled.save(&mut output, PNG).unwrap();
+        scaled.write_to(&mut output, PNG).unwrap();
     }
 }

--- a/examples/scaleup/main.rs
+++ b/examples/scaleup/main.rs
@@ -38,12 +38,12 @@ fn main() {
         let scaled = tiny.resize(32, 32, filter);
         println!("Scaled by {} in {}", name, Elapsed::from(&timer));
         let mut output = File::create(&format!("up2-{}.png", name)).unwrap();
-        scaled.save(&mut output, PNG).unwrap();
+        scaled.write_to(&mut output, PNG).unwrap();
 
         let timer = Instant::now();
         let scaled = tiny.resize(48, 48, filter);
         println!("Scaled by {} in {}", name, Elapsed::from(&timer));
         let mut output = File::create(&format!("up3-{}.png", name)).unwrap();
-        scaled.save(&mut output, PNG).unwrap();
+        scaled.write_to(&mut output, PNG).unwrap();
     }
 }

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -9,17 +9,17 @@ fn jqeg_qualitys() {
     let img = image::open("tests/images/tiff/testsuite/lenna.tiff").unwrap();
 
     let mut default = vec![];
-    img.save(&mut default, JPEG).unwrap();
+    img.write_to(&mut default, JPEG).unwrap();
     assert_eq!(&[255, 216], &default[..2]);
 
     let mut small = vec![];
-    img.save(&mut small, ImageOutputFormat::JPEG(10)).unwrap();
+    img.write_to(&mut small, ImageOutputFormat::JPEG(10)).unwrap();
     assert_eq!(&[255, 216], &small[..2]);
 
     assert!(small.len() < default.len());
 
     let mut large = vec![];
-    img.save(&mut large, ImageOutputFormat::JPEG(99)).unwrap();
+    img.write_to(&mut large, ImageOutputFormat::JPEG(99)).unwrap();
     assert_eq!(&[255, 216], &large[..2]);
 
     assert!(large.len() > default.len());


### PR DESCRIPTION
I forgot to change the examples and tests in my last PR and now the builds are failing... 😳

I decided the quickest fix was to switch the `save`s to `write_to`s.

Sorry for the failed builds!