### PR TITLE
Improve subimages

### DIFF
--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs::File;
 use std::path::Path;
 
-use image::GenericImage;
+use image::GenericImageView;
 
 fn main() {
     let file = if env::args().count() == 2 {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -512,6 +512,7 @@ where
     P::Subpixel: 'static,
 {
     type Pixel = P;
+    type InnerImage = Self;
 
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions()
@@ -561,6 +562,14 @@ where
     /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
     fn blend_pixel(&mut self, x: u32, y: u32, p: P) {
         self.get_pixel_mut(x, y).blend(&p)
+    }
+
+    fn inner(&self) -> &Self::InnerImage {
+        self
+    }
+
+    fn inner_mut(&mut self) -> &mut Self::InnerImage {
+        self
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -467,6 +467,7 @@ impl DynamicImage {
 #[allow(deprecated)]
 impl GenericImage for DynamicImage {
     type Pixel = color::Rgba<u8>;
+    type InnerImage = DynamicImage;
 
     fn dimensions(&self) -> (u32, u32) {
         dynamic_map!(*self, ref p -> p.dimensions())
@@ -501,6 +502,14 @@ impl GenericImage for DynamicImage {
     /// DEPRECATED: Do not use is function: It is unimplemented!
     fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
         unimplemented!()
+    }
+
+    fn inner(&self) -> &Self::InnerImage {
+        self
+    }
+
+    fn inner_mut(&mut self) -> &mut Self::InnerImage {
+        self
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -29,7 +29,8 @@ use webp;
 use buffer::{ConvertBuffer, GrayAlphaImage, GrayImage, ImageBuffer, Pixel, RgbImage, RgbaImage};
 use color;
 use image;
-use image::{GenericImage, ImageDecoder, ImageFormat, ImageOutputFormat, ImageResult};
+use image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat,
+            ImageResult};
 use imageops;
 
 use image::DecodingResult::U8;
@@ -465,9 +466,9 @@ impl DynamicImage {
 }
 
 #[allow(deprecated)]
-impl GenericImage for DynamicImage {
+impl GenericImageView for DynamicImage {
     type Pixel = color::Rgba<u8>;
-    type InnerImage = DynamicImage;
+    type InnerImageView = Self;
 
     fn dimensions(&self) -> (u32, u32) {
         dynamic_map!(*self, ref p -> p.dimensions())
@@ -480,6 +481,15 @@ impl GenericImage for DynamicImage {
     fn get_pixel(&self, x: u32, y: u32) -> color::Rgba<u8> {
         dynamic_map!(*self, ref p -> p.get_pixel(x, y).to_rgba())
     }
+
+    fn inner(&self) -> &Self::InnerImageView {
+        self
+    }
+}
+
+#[allow(deprecated)]
+impl GenericImage for DynamicImage {
+    type InnerImage = DynamicImage;
 
     fn put_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
         match *self {
@@ -502,10 +512,6 @@ impl GenericImage for DynamicImage {
     /// DEPRECATED: Do not use is function: It is unimplemented!
     fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
         unimplemented!()
-    }
-
-    fn inner(&self) -> &Self::InnerImage {
-        self
     }
 
     fn inner_mut(&mut self) -> &mut Self::InnerImage {

--- a/src/image.rs
+++ b/src/image.rs
@@ -497,7 +497,7 @@ pub trait GenericImage: GenericImageView + Sized {
     /// be copied due to size constraints.
     fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> bool
     where
-        O: GenericImage<Pixel = Self::Pixel>,
+        O: GenericImageView<Pixel = Self::Pixel>,
     {
         // Do bounds checking here so we can use the non-bounds-checking
         // functions to copy pixels.

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,11 +1,11 @@
 //! Functions for performing affine transformations.
 
 use buffer::{ImageBuffer, Pixel};
-use image::GenericImage;
+use image::GenericImageView;
 
 /// Rotate an image 90 degrees clockwise.
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate90<I: GenericImage + 'static>(
+pub fn rotate90<I: GenericImageView + 'static>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
@@ -27,7 +27,7 @@ where
 
 /// Rotate an image 180 degrees clockwise.
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate180<I: GenericImage + 'static>(
+pub fn rotate180<I: GenericImageView + 'static>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
@@ -49,7 +49,7 @@ where
 
 /// Rotate an image 270 degrees clockwise.
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate270<I: GenericImage + 'static>(
+pub fn rotate270<I: GenericImageView + 'static>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
@@ -71,7 +71,7 @@ where
 
 /// Flip an image horizontally
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn flip_horizontal<I: GenericImage + 'static>(
+pub fn flip_horizontal<I: GenericImageView + 'static>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
@@ -93,7 +93,7 @@ where
 
 /// Flip an image vertically
 // TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn flip_vertical<I: GenericImage + 'static>(
+pub fn flip_vertical<I: GenericImageView + 'static>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -2,7 +2,7 @@
 
 use buffer::{ImageBuffer, Pixel};
 use color::{Luma, Rgba};
-use image::GenericImage;
+use image::{GenericImage, GenericImageView};
 use math::nq;
 use math::utils::clamp;
 use num_traits::{Num, NumCast};
@@ -10,7 +10,7 @@ use std::f64::consts::PI;
 use traits::Primitive;
 
 /// Convert the supplied image to grayscale
-pub fn grayscale<I: GenericImage>(
+pub fn grayscale<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<Luma<<I::Pixel as Pixel>::Subpixel>, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
@@ -50,7 +50,7 @@ pub fn invert<I: GenericImage>(image: &mut I) {
 /// Negative values decrease the contrast and positive values increase the contrast.
 pub fn contrast<I, P, S>(image: &I, contrast: f32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P>,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -85,7 +85,7 @@ where
 /// Negative values decrease the brightness and positive values increase it.
 pub fn brighten<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P>,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -120,7 +120,7 @@ where
 /// just like the css webkit filter hue-rotate(180)
 pub fn huerotate<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P>,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -1,7 +1,7 @@
 //! Image Processing Functions
 use std::cmp;
 
-use image::{GenericImage, SubImage};
+use image::{GenericImage, GenericImageView, SubImage};
 
 use buffer::Pixel;
 
@@ -26,18 +26,13 @@ pub mod colorops;
 mod sample;
 
 /// Return a mutable view into an image
-// TODO: Is a 'static bound on `I` really required? Acn we avoid it?
-pub fn crop<I: GenericImage + 'static>(
+pub fn crop<I: GenericImageView>(
     image: &mut I,
     x: u32,
     y: u32,
     width: u32,
     height: u32,
-) -> SubImage<&mut I>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
-{
+) -> SubImage<&mut I> {
     let (iwidth, iheight) = image.dimensions();
 
     let x = cmp::min(x, iwidth);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -8,7 +8,7 @@ use std::f32;
 use num_traits::{NumCast, Zero};
 
 use buffer::{ImageBuffer, Pixel};
-use image::GenericImage;
+use image::GenericImageView;
 use math::utils::clamp;
 use traits::{Enlargeable, Primitive};
 
@@ -129,7 +129,7 @@ fn horizontal_sample<I, P, S>(
     filter: &mut Filter,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P> + 'static,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -217,7 +217,7 @@ fn vertical_sample<I, P, S>(
     filter: &mut Filter,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P> + 'static,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -289,7 +289,7 @@ where
 /// Resize the supplied image down to the specific dimensions.
 pub fn thumbnail<I, P, S>(image: &I, new_width: u32, new_height: u32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P>,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + Enlargeable + 'static,
 {
@@ -355,7 +355,7 @@ where
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32]) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P> + 'static,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -434,7 +434,7 @@ where
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
-pub fn resize<I: GenericImage + 'static>(
+pub fn resize<I: GenericImageView + 'static>(
     image: &I,
     nwidth: u32,
     nheight: u32,
@@ -474,7 +474,7 @@ where
 /// Performs a Gaussian blur on the supplied image.
 /// ```sigma``` is a measure of how much to blur by.
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
-pub fn blur<I: GenericImage + 'static>(
+pub fn blur<I: GenericImageView + 'static>(
     image: &I,
     sigma: f32,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
@@ -505,7 +505,7 @@ where
 // TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImage<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P> + 'static,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use color::{Luma, LumaA, Rgb, Rgba};
 
 pub use image::{DecodingResult,
                 GenericImage,
+                GenericImageView,
                 ImageDecoder,
                 ImageError,
                 ImageResult,


### PR DESCRIPTION
This PR mainly involves 3 changes:

1. remove the `'static` requirement for `Self` in `sub_image` and `view`. This allows to call `sub_image` and `view` not only on an image but also on `SubImage`s;
2. add a new associated type `InnerImage` to `GenericImage` which allows to specify the return type of `sub_image` and `view`. This allows to avoid some layers of indirections in the case of `SubImages` because we can reference the original image directly. Previously nested calls to `sub_image` would result in a type like `SubImage<SubImage<SubImage<&mut I>>>` while with this PR the type would always be `SubImage<&mut I>`. On top of this,  this also makes it easy to work with `SubImage`s recursively.
3. move non mutating methods from `GenericImage` to `GenericImageView`. This allows multiple views into the same image to coexist. It should also allow to use `rayon` to process each of the views concurrently.

Unfortunately 2 and 3 can break existing code because 2 added new methods to the traits and 3 moved the `Pixel` associated type into `GenericImageView`.

However, I think this PR improves the usability of `SubImage`s imho. Take a look at the following example:

https://github.com/d-dorazio/mattors/blob/8725a4bfb769484d142d6526ddd823d77d86c1bc/src/main.rs#L515-L551

The code makes a recursive use of `SubImage`s which doesn't compile without this changeset.


I also plan to make another change in `GenericImageView` that is change `get_pixel` to return a ref to the Pixel and not a copy, but I'll do it in another PR relatively soon.