### PR TITLE
added gif encoding for multiple frames

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -421,9 +421,9 @@ impl DynamicImage {
 
             #[cfg(feature = "gif_codec")]
             image::ImageOutputFormat::GIF => {
-                let g = gif::Encoder::new(w);
+                let mut g = gif::Encoder::new(w);
 
-                try!(g.encode(gif::Frame::from_rgba(
+                try!(g.encode(&gif::Frame::from_rgba(
                     width as u16,
                     height as u16,
                     &mut *self.to_rgba().iter().cloned().collect::<Vec<u8>>()


### PR DESCRIPTION
This basically just adds the ability to encode frames into a gif file without a user needing the `gif` crate.

So now, a user can create a gif with the following code:
```rust
if let Ok(file) = File::create("foo.gif") {
    let mut encoder = image::gif::Encoder::new(file);
    for frame in frames {
        encoder.encode(&frame);
    }
}
```
where `frames` is a `Vec` of [`image::gif::Frame`](https://docs.rs/image/0.19.0/image/gif/struct.Frame.html)

or 

```rust
if let Ok(file) = File::create("foo.gif") {
    let mut encoder = image::gif::Encoder::new(file);
    encoder.encode_frames(frames);
}
```
where `frames` is an [`image::Frames`](https://docs.rs/image/0.19.0/image/struct.Frames.html).

I also added some docs at the top to demonstrate an example of decoding and encoding. 