### PR TITLE
Fix ordering of interpolated parameters in TIFF decode error string

### DIFF
--- a/src/tiff/decoder/mod.rs
+++ b/src/tiff/decoder/mod.rs
@@ -487,7 +487,7 @@ impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
 
             _ => Err(::image::ImageError::UnsupportedError(format!(
                 "{:?} with {:?} bits per sample is unsupported",
-                self.bits_per_sample, self.photometric_interpretation
+                self.photometric_interpretation, self.bits_per_sample
             ))), // TODO: this is bad we should not fail at this point}
         }
     }


### PR DESCRIPTION
Currently, the ordering of the parameters in the error string mean you get a result like this:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UnsupportedError("[8] with RGBPalette bits per sample is unsupported")', libcore/result.rs:945:5
```

When really, it should look like this:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UnsupportedError("RGBPalette with [8] bits per sample is unsupported")', libcore/result.rs:945:5
```

(Technically, the 'fixed' error message is still wrong, as that was actually a CIELab image with [8, 8, 8] encoding. However, since that's not supported yet, getting the error response to be less confusing is a step forward.)
