### PR TITLE
Update the fractal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,8 @@ fn main() {
 ### 6.2 Generating Fractals
 ```rust
 //! An example of generating julia fractals.
-extern crate num_complex;
 extern crate image;
-
-use std::fs::File;
-use std::path::Path;
+extern crate num_complex;
 
 use num_complex::Complex;
 
@@ -226,7 +223,7 @@ fn main() {
     let scaley = 4.0 / imgy as f32;
 
     // Create a new ImgBuf with width: imgx and height: imgy
-    let mut imgbuf = image::ImageBuffer::new(imgx, imgy);
+    let mut imgbuf = image::GrayImage::new(imgx, imgy);
 
     // Iterate over the coordinates and pixels of the image
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
@@ -249,15 +246,10 @@ fn main() {
         // Create an 8bit pixel of type Luma and value i
         // and assign in to the pixel at position (x, y)
         *pixel = image::Luma([i as u8]);
-
     }
 
-
-    // Save the image as “fractal.png”
-    let ref mut fout = File::create("fractal.png").unwrap();
-
-    // We must indicate the image's color type and what format to save as
-    image::ImageLuma8(imgbuf).save(fout, image::PNG).unwrap();
+    // Save the image as “fractal.png”, the format is deduced from the path
+    imgbuf.save("fractal.png").unwrap();
 }
 ```
 

--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -2,8 +2,6 @@
 extern crate image;
 extern crate num_complex;
 
-use std::fs::File;
-
 use num_complex::Complex;
 
 fn main() {
@@ -16,7 +14,7 @@ fn main() {
     let scaley = 4.0 / imgy as f32;
 
     // Create a new ImgBuf with width: imgx and height: imgy
-    let mut imgbuf = image::ImageBuffer::new(imgx, imgy);
+    let mut imgbuf = image::GrayImage::new(imgx, imgy);
 
     // Iterate over the coordinates and pixels of the image
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
@@ -30,7 +28,7 @@ fn main() {
 
         for t in 0..max_iterations {
             if z.norm() > 2.0 {
-                break;
+                break
             }
             z = z * z + c;
             i = t;
@@ -41,11 +39,6 @@ fn main() {
         *pixel = image::Luma([i as u8]);
     }
 
-    // Save the image as “fractal.png”
-    let fout = &mut File::create("fractal.png").unwrap();
-
-    // We must indicate the image's color type and what format to save as
-    image::ImageLuma8(imgbuf)
-        .write_to(fout, image::PNG)
-        .unwrap();
+    // Save the image as “fractal.png”, the format is deduced from the path
+    imgbuf.save("fractal.png").unwrap();
 }


### PR DESCRIPTION
Several steps are now more idiomatic
- Uses `.save`, which automatically deduces the format
- Indicates the color directly with `GrayImage`, removing a second
  explicit annotation later
- Directly stores the `ImageBuffer` instead of converting to a
  `DynamicImage` first

Fixes #775 