### PR TITLE
Fix the doc comment for get_pixel_mut

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -433,7 +433,7 @@ pub trait GenericImage: GenericImageView {
     /// indirections and it eases the use of nested SubImages.
     type InnerImage: GenericImage<Pixel = Self::Pixel>;
 
-    /// Puts a pixel at location (x, y)
+    /// Gets a reference to the mutable pixel at location `(x, y)`
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The doc comment for get_pixel_mut describes
the put_pixel method instead of the get_pixel_mut
method. This commit copies the get_pixel_mut doc
comment from buffer.rs and replaces the doc comment
in image.rs.