### PR TITLE
Fix move of overlapping buffers in bmp/decoder

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -167,21 +167,14 @@ fn extend_buffer(buffer: &mut Vec<u8>, full_size: usize, blank: bool) -> &mut [u
     let extend = full_size - buffer.len();
 
     buffer.extend(repeat(0xFF).take(extend));
-
-    let buffer_len = buffer.len();
+    assert_eq!(buffer.len(), full_size);
 
     let ret = if extend >= old_size {
         // If the full buffer length is more or equal to twice the initial one, we can simply
         // copy the data in the lower part of the buffer to the end of it and input from there.
-        {
-            let (lower, upper) = buffer.split_at_mut(old_size);
-            let upper_len = upper.len();
-            let lower_len = lower.len();
-
-            upper[upper_len - lower_len..].copy_from_slice(lower);
-        }
-
-        &mut buffer[..buffer_len - old_size]
+        let (new, old) = buffer.split_at_mut(extend);
+        old.copy_from_slice(&new[..old_size]);
+        new
     } else {
         // If the full size is less than twice the initial buffer, we have to
         // copy in two steps

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -185,18 +185,15 @@ fn extend_buffer(buffer: &mut Vec<u8>, full_size: usize, blank: bool) -> &mut [u
     } else {
         // If the full size is less than twice the initial buffer, we have to
         // copy in two steps
+        let overlap = old_size - extend;
 
         // First we copy the data that fits into the bit we extended.
         let (lower, upper) = buffer.split_at_mut(old_size);
-        let upper_len = upper.len();
-        let lower_len = lower.len();
-        upper.copy_from_slice(&lower[lower_len - upper_len..]);
+        upper.copy_from_slice(&lower[overlap..]);
 
         // Then we slide the data that hasn't been copied yet to the top of the buffer
         let (new, old) = lower.split_at_mut(extend);
-        let new_len = new.len();
-        let old_len = old.len();
-        old.copy_from_slice(&new[new_len - old_len..]);
+        old[..overlap].copy_from_slice(&new[..overlap]);
         new
     };
     if blank {


### PR DESCRIPTION
Fixes #789 

I didn't add a test because that requires a test file size of at least 134MB.