### PR TITLE
Fix and improve pbm decoding

### DIFF
--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -1,5 +1,5 @@
 use std::io::{self, BufRead, BufReader, Read};
-use std::str::FromStr;
+use std::str::{self, FromStr};
 use std::fmt::Display;
 
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
@@ -513,7 +513,7 @@ fn read_separated_ascii<T: FromStr>(reader: &mut Read) -> ImageResult<T>
         ));
     }
 
-    let string = String::from_utf8(token)
+    let string = str::from_utf8(&token)
         // We checked the precondition ourselves a few lines before, `token.is_ascii()`.
         .unwrap_or_else(|_| unreachable!("Only ascii characters should be decoded"));
 

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -680,7 +680,7 @@ impl Sample for BWBit {
         _height: u32,
         _samples: u32,
     ) -> ImageResult<Vec<Self::T>> {
-        panic!("BW bits from anymaps are never encoded as ascii")
+        unreachable!("BW bits from anymaps are never encoded as ascii")
     }
 }
 


### PR DESCRIPTION
Addresses the issues found in #799 

* Io errors can no longer lead to infinite loops but will instead break early
* `pbm` decoding now works properly without separators, which are optional in contrast to the formats