### PR TITLE
Update num-rational dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ path = "./src/lib.rs"
 [dependencies]
 byteorder = "1.2.1"
 num-iter = "0.1.32"
-num-rational = { version = "0.1.32", default-features = false }
+num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
 lzw = "0.10.0"
 


### PR DESCRIPTION
The ecosystem seems to be moving to v2, and I'd like to avoid duplication of this crate.

(Would be nice if this could be accompanied by a version bump / publish)

r? @bvssvni