### PR TITLE
Clippy lint pass

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1262,7 +1262,7 @@ mod test {
     #[test]
     fn test_bitfield_len() {
         for len in 1..9 {
-            let bitfield = Bitfield { shift: 0, len: len };
+            let bitfield = Bitfield { shift: 0, len };
             for i in 0..(1 << len) {
                 let read = bitfield.read(i);
                 let calc = (i as f64 / ((1 << len) - 1) as f64 * 255f64).round() as u8;

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -27,7 +27,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         let bmp_header_size = 14;
         let dib_header_size = 40; // using BITMAPINFOHEADER
 
-        let (raw_pixel_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(&c));
+        let (raw_pixel_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(c));
         let row_pad_size = (4 - (width * written_pixel_size) % 4) % 4; // each row must be padded to a multiple of 4 bytes
 
         let image_size = width * height * written_pixel_size + (height * row_pad_size);
@@ -72,7 +72,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    &get_unsupported_error_message(&c)[..],
+                    &get_unsupported_error_message(c)[..],
                 ))
             }
         }
@@ -157,7 +157,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
     }
 }
 
-fn get_unsupported_error_message(c: &color::ColorType) -> String {
+fn get_unsupported_error_message(c: color::ColorType) -> String {
     format!(
         "Unsupported color type {:?}.  Supported types: RGB(8), RGBA(8), Gray(8), GrayA(8).",
         c
@@ -165,8 +165,8 @@ fn get_unsupported_error_message(c: &color::ColorType) -> String {
 }
 
 /// Returns a tuple representing: (raw pixel size, written pixel size, palette color count).
-fn get_pixel_info(c: &color::ColorType) -> io::Result<(u32, u32, u32)> {
-    let sizes = match *c {
+fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
+    let sizes = match c {
         color::ColorType::RGB(8) => (3, 3, 0),
         color::ColorType::RGBA(8) => (4, 3, 0),
         color::ColorType::Gray(8) => (1, 1, 256),

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -31,24 +31,24 @@ pub enum DXTVariant {
 impl DXTVariant {
     /// Returns the amount of bytes of raw image data
     /// that is encoded in a single DXTn block
-    fn decoded_bytes_per_block(&self) -> usize {
-        match *self {
+    fn decoded_bytes_per_block(self) -> usize {
+        match self {
             DXTVariant::DXT1 => 48,
             DXTVariant::DXT3 | DXTVariant::DXT5 => 64,
         }
     }
 
     /// Returns the amount of bytes per block of encoded DXTn data
-    fn encoded_bytes_per_block(&self) -> usize {
-        match *self {
+    fn encoded_bytes_per_block(self) -> usize {
+        match self {
             DXTVariant::DXT1 => 8,
             DXTVariant::DXT3 | DXTVariant::DXT5 => 16,
         }
     }
 
     /// Returns the colortype that is stored in this DXT variant
-    pub fn colortype(&self) -> ColorType {
-        match *self {
+    pub fn colortype(self) -> ColorType {
+        match self {
             DXTVariant::DXT1 => ColorType::RGB(8),
             DXTVariant::DXT3 | DXTVariant::DXT5 => ColorType::RGBA(8),
         }
@@ -217,7 +217,7 @@ fn square(a: i32) -> i32 {
 }
 
 /// returns the squared error between two RGB values
-fn diff(a: &Rgb, b: &Rgb) -> i32 {
+fn diff(a: Rgb, b: Rgb) -> i32 {
     square(i32::from(a[0]) - i32::from(b[0])) + square(i32::from(a[1]) - i32::from(b[1]))
         + square(i32::from(a[2]) - i32::from(b[2]))
 }
@@ -456,7 +456,7 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8]) {
         let mut rgb = targets
             .iter()
             .cloned()
-            .max_by_key(|rgb| diff(rgb, &ref_rgb))
+            .max_by_key(|rgb| diff(*rgb, ref_rgb))
             .unwrap();
         // amplify differences by 2.5, which should push them to the next quantized value
         // if possible without overshoot
@@ -529,7 +529,7 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8]) {
                 // pixel.
                 let total_error = targets
                     .iter()
-                    .map(|t| colors.iter().map(|c| diff(c, t) as u32).min().unwrap())
+                    .map(|t| colors.iter().map(|c| diff(*c, *t) as u32).min().unwrap())
                     .sum();
 
                 // update the match if we found a better one
@@ -554,7 +554,7 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8]) {
         let (idx, _) = chosen_colors
             .iter()
             .enumerate()
-            .min_by_key(|&(_, c)| diff(c, t))
+            .min_by_key(|&(_, c)| diff(*c, *t))
             .unwrap();
         chosen_indices = (chosen_indices << 2) | idx as u32;
     }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -23,6 +23,7 @@
 //! # Ok(())
 //! # }
 //! ```
+#![cfg_attr(feature = "cargo-clippy", allow(while_let_loop))]
 
 extern crate gif;
 extern crate num_rational;
@@ -264,10 +265,9 @@ impl<W: Write> Encoder<W> {
             frame.delay = frame_delay;
 
             // encode the gif::Frame
-            match self.encode(&frame).map_err(|err| err.into()) {
-                Ok(()) => (),
-                Err(e) => return Err(e),
-            };
+            if let Err(e) = self.encode(&frame) {
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -532,6 +532,12 @@ pub struct SubImage<I> {
     ystride: u32,
 }
 
+/// Alias to access Pixel behind a reference
+type DerefPixel<I> = <<I as Deref>::Target as GenericImageView>::Pixel;
+
+/// Alias to access Subpixel behind a reference
+type DerefSubpixel<I> = <DerefPixel<I> as Pixel>::Subpixel;
+
 impl<I> SubImage<I> {
     /// Construct a new subimage
     pub fn new(image: I, x: u32, y: u32, width: u32, height: u32) -> SubImage<I> {
@@ -555,9 +561,7 @@ impl<I> SubImage<I> {
     /// Convert this subimage to an ImageBuffer
     pub fn to_image(
         &self,
-    ) -> ImageBuffer<
-        <I::Target as GenericImageView>::Pixel,
-        Vec<<<I::Target as GenericImageView>::Pixel as Pixel>::Subpixel>,
+    ) -> ImageBuffer<DerefPixel<I>, Vec<DerefSubpixel<I>>,
     >
     where
         I: Deref,
@@ -583,7 +587,7 @@ where
     I: Deref,
     I::Target: GenericImageView + Sized,
 {
-    type Pixel = <I::Target as GenericImageView>::Pixel;
+    type Pixel = DerefPixel<I>;
     type InnerImageView = I::Target;
 
     fn dimensions(&self) -> (u32, u32) {

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -9,13 +9,15 @@ use num_traits::{Num, NumCast};
 use std::f64::consts::PI;
 use traits::Primitive;
 
+type Subpixel<I> = <<I as GenericImageView>::Pixel as Pixel>::Subpixel;
+
 /// Convert the supplied image to grayscale
 pub fn grayscale<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<Luma<<I::Pixel as Pixel>::Subpixel>, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> ImageBuffer<Luma<Subpixel<I>>, Vec<Subpixel<I>>>
 where
-    <I::Pixel as Pixel>::Subpixel: 'static,
-    <<I::Pixel as Pixel>::Subpixel as Num>::FromStrRadixErr: 'static,
+    Subpixel<I>: 'static,
+    <Subpixel<I> as Num>::FromStrRadixErr: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+
 use byteorder::{BigEndian, WriteBytesExt};
 use math::utils::clamp;
 use num_iter::range_step;

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -870,12 +870,11 @@ impl<R: Read> VP8Decoder<R> {
     }
 
     fn update_token_probabilities(&mut self) {
-        for i in 0usize..4 {
-            for j in 0usize..8 {
-                for k in 0usize..3 {
-                    for t in 0usize..NUM_DCT_TOKENS - 1 {
-                        let prob = COEFF_UPDATE_PROBS[i][j][k][t];
-                        if self.b.read_bool(prob) != 0 {
+        for (i, is) in COEFF_UPDATE_PROBS.iter().enumerate() {
+            for (j, js) in is.iter().enumerate() {
+                for (k, ks) in js.iter().enumerate() {
+                    for (t, prob) in ks.iter().enumerate().take(NUM_DCT_TOKENS - 1) {
+                        if self.b.read_bool(*prob) != 0 {
                             let v = self.b.read_literal(8);
                             self.token_probs[i][j][k][t] = v;
                         }


### PR DESCRIPTION
I've implemented some suggestions from clippy-preview. There were two issues I had to ignore:
* `too_many_arguments` in `jpeg/encoder` since factoring out variables wouldn't improve this code clarity much.
* `while_let_loop` in `gif` since this would borrow the `reader` for the entire loop body. I'm not sure if this is something Clippy ought to be aware of or not.

Either way - this makes Image clean with Clippy on Rust stable.