### PR TITLE
Restructure ImageDecoder trait

### DIFF
--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -187,7 +187,7 @@ mod tests {
     use super::super::BMPDecoder;
     use super::BMPEncoder;
     use color::ColorType;
-    use image::{DecodingResult, ImageDecoder};
+    use image::ImageDecoder;
     use std::io::Cursor;
 
     fn round_trip_image(image: &[u8], width: u32, height: u32, c: ColorType) -> Vec<u8> {
@@ -199,11 +199,8 @@ mod tests {
                 .expect("could not encode image");
         }
 
-        let mut decoder = BMPDecoder::new(Cursor::new(&encoded_data));
-        match decoder.read_image().expect("failed to decode") {
-            DecodingResult::U8(decoded) => decoded,
-            _ => panic!("failed to decode"),
-        }
+        let decoder = BMPDecoder::new(Cursor::new(&encoded_data)).expect("failed to decode");
+        decoder.read_image().expect("failed to decode")
     }
 
     #[test]

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -7,10 +7,10 @@
 //!
 //!  Note: this module only implements bare DXT encoding/decoding, it does not parse formats that can contain DXT files like .dds
 
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 use color::ColorType;
-use image::{DecodingResult, ImageDecoder, ImageError, ImageResult};
+use image::{ImageReadBuffer, ImageDecoder, ImageError, ImageResult};
 
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're
@@ -94,24 +94,10 @@ impl<R: Read> DXTDecoder<R> {
             row: 0,
         })
     }
-}
 
-/// Note that, due to the way that DXT compression works, a scanline is considered
-/// to consist out of 4 lines of pixels.
-impl<R: Read> ImageDecoder for DXTDecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        Ok((self.width_blocks * 4, self.height_blocks * 4))
-    }
+    fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        assert_eq!(buf.len(), self.scanline_bytes());
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        Ok(self.variant.colortype())
-    }
-
-    fn row_len(&mut self) -> ImageResult<usize> {
-        Ok(self.variant.decoded_bytes_per_block() * self.width_blocks as usize)
-    }
-
-    fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
         let mut src =
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
         self.inner.read_exact(&mut src)?;
@@ -120,17 +106,53 @@ impl<R: Read> ImageDecoder for DXTDecoder<R> {
             DXTVariant::DXT3 => decode_dxt3_row(&src, buf),
             DXTVariant::DXT5 => decode_dxt5_row(&src, buf),
         }
-        let rv = self.row;
         self.row += 1;
-        Ok(rv)
+        Ok(buf.len())
+    }
+}
+
+/// Note that, due to the way that DXT compression works, a scanline is considered
+/// to consist out of 4 lines of pixels.
+impl<R: Read> ImageDecoder for DXTDecoder<R> {
+    type Reader = DXTReader<R>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        (self.width_blocks * 4, self.height_blocks * 4)
     }
 
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        let mut dest = vec![0u8; self.height_blocks as usize * self.row_len()?];
-        for chunk in dest.chunks_mut(self.row_len()?) {
+    fn colortype(&self) -> ColorType {
+        self.variant.colortype()
+    }
+
+    fn scanline_bytes(&self) -> usize {
+        self.variant.decoded_bytes_per_block() * self.width_blocks as usize
+    }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(DXTReader {
+            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
+            decoder: self,
+        })
+    }
+
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+        let mut dest = vec![0u8; self.total_bytes()];
+        for chunk in dest.chunks_mut(self.scanline_bytes()) {
             self.read_scanline(chunk)?;
         }
-        Ok(DecodingResult::U8(dest))
+        Ok(dest)
+    }
+}
+
+/// DXT reader
+pub struct DXTReader<R: Read> {
+    buffer: ImageReadBuffer,
+    decoder: DXTDecoder<R>,
+}
+impl<R: Read> Read for DXTReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let ref mut decoder = &mut self.decoder;
+        self.buffer.read(buf, |buf| decoder.read_scanline(buf))
     }
 }
 

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use color::ColorType;
-use image::{DecodingResult, ImageDecoder, ImageError, ImageResult};
+use image::{ImageDecoder, ImageError, ImageResult};
 
 use self::InnerDecoder::*;
 use bmp::BMPDecoder;
@@ -151,47 +151,44 @@ impl DirEntry {
         try!(self.seek_to_start(&mut r));
 
         if is_png {
-            Ok(PNG(PNGDecoder::new(r)))
+            Ok(PNG(PNGDecoder::new(r)?))
         } else {
-            let mut decoder = BMPDecoder::new(r);
-            try!(decoder.read_metadata_in_ico_format());
-            Ok(BMP(decoder))
+            Ok(BMP(BMPDecoder::new_with_ico_format(r)?))
         }
     }
 }
 
 impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
         match self.inner_decoder {
-            BMP(ref mut decoder) => decoder.dimensions(),
-            PNG(ref mut decoder) => decoder.dimensions(),
+            BMP(ref decoder) => decoder.dimensions(),
+            PNG(ref decoder) => decoder.dimensions(),
         }
     }
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
+    fn colortype(&self) -> ColorType {
         match self.inner_decoder {
-            BMP(ref mut decoder) => decoder.colortype(),
-            PNG(ref mut decoder) => decoder.colortype(),
+            BMP(ref decoder) => decoder.colortype(),
+            PNG(ref decoder) => decoder.colortype(),
         }
     }
 
-    fn row_len(&mut self) -> ImageResult<usize> {
-        match self.inner_decoder {
-            BMP(ref mut decoder) => decoder.row_len(),
-            PNG(ref mut decoder) => decoder.row_len(),
-        }
+    // fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
+    //     match self.inner_decoder {
+    //         BMP(ref mut decoder) => decoder.read_scanline(buf),
+    //         PNG(ref mut decoder) => decoder.read_scanline(buf),
+    //     }
+    // }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(self.read_image()?))
     }
 
-    fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
+    fn read_image(self) -> ImageResult<Vec<u8>> {
         match self.inner_decoder {
-            BMP(ref mut decoder) => decoder.read_scanline(buf),
-            PNG(ref mut decoder) => decoder.read_scanline(buf),
-        }
-    }
-
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        match self.inner_decoder {
-            PNG(ref mut decoder) => {
+            PNG(decoder) => {
                 if self.selected_entry.image_length < PNG_SIGNATURE.len() as u32 {
                     return Err(ImageError::FormatError(
                         "Entry specified a length that is shorter than PNG header!".to_string(),
@@ -199,7 +196,7 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
                 }
 
                 // Check if the image dimensions match the ones in the image data.
-                let (width, height) = try!(decoder.dimensions());
+                let (width, height) = decoder.dimensions();
                 if !self.selected_entry.matches_dimensions(width, height) {
                     return Err(ImageError::FormatError(
                         "Entry and PNG dimensions do not match!".to_string(),
@@ -208,7 +205,7 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
 
                 // Embedded PNG images can only be of the 32BPP RGBA format.
                 // https://blogs.msdn.microsoft.com/oldnewthing/20101022-00/?p=12473/
-                let color_type = try!(decoder.colortype());
+                let color_type = decoder.colortype();
                 if let ColorType::RGBA(8) = color_type {
                 } else {
                     return Err(ImageError::FormatError(
@@ -218,8 +215,8 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
 
                 decoder.read_image()
             }
-            BMP(ref mut decoder) => {
-                let (width, height) = try!(decoder.dimensions());
+            BMP(mut decoder) => {
+                let (width, height) = decoder.dimensions();
                 if !self.selected_entry.matches_dimensions(width, height) {
                     return Err(ImageError::FormatError(
                         "Entry({:?}) and BMP({:?}) dimensions do not match!".to_string(),
@@ -227,16 +224,13 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
                 }
 
                 // The ICO decoder needs an alpha channel to apply the AND mask.
-                if try!(decoder.colortype()) != ColorType::RGBA(8) {
+                if decoder.colortype() != ColorType::RGBA(8) {
                     return Err(ImageError::UnsupportedError(
                         "Unsupported color type".to_string(),
                     ));
                 }
 
-                let mut pixel_data = match try!(decoder.read_image()) {
-                    DecodingResult::U8(v) => v,
-                    _ => unreachable!(),
-                };
+                let mut pixel_data = decoder.read_image_data()?;
 
                 // If there's an AND mask following the image, read and apply it.
                 let r = decoder.reader();
@@ -271,7 +265,7 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
                         }
                     }
                 }
-                Ok(DecodingResult::U8(pixel_data))
+                Ok(pixel_data)
             }
         }
     }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,72 +1,59 @@
 extern crate jpeg_decoder;
 
-use std::io::Read;
+use std::io::{Cursor, Read};
 
-use color::{self, ColorType};
-use image::{DecodingResult, ImageDecoder, ImageError, ImageResult};
+use color::ColorType;
+use image::{ImageDecoder, ImageError, ImageResult};
 
 /// JPEG decoder
 pub struct JPEGDecoder<R> {
     decoder: jpeg_decoder::Decoder<R>,
-    metadata: Option<jpeg_decoder::ImageInfo>,
+    metadata: jpeg_decoder::ImageInfo,
 }
 
 impl<R: Read> JPEGDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> JPEGDecoder<R> {
-        JPEGDecoder {
-            decoder: jpeg_decoder::Decoder::new(r),
-            metadata: None,
+    pub fn new(r: R) -> ImageResult<JPEGDecoder<R>> {
+        let mut decoder = jpeg_decoder::Decoder::new(r);
+
+        decoder.read_info()?;
+        let mut metadata = decoder.info().unwrap();
+
+        // We convert CMYK data to RGB before returning it to the user.
+        if metadata.pixel_format == jpeg_decoder::PixelFormat::CMYK32 {
+            metadata.pixel_format = jpeg_decoder::PixelFormat::RGB24;
         }
-    }
 
-    fn metadata(&mut self) -> ImageResult<jpeg_decoder::ImageInfo> {
-        match self.metadata {
-            Some(metadata) => Ok(metadata),
-            None => {
-                try!(self.decoder.read_info());
-                let mut metadata = self.decoder.info().unwrap();
-
-                // We convert CMYK data to RGB before returning it to the user.
-                if metadata.pixel_format == jpeg_decoder::PixelFormat::CMYK32 {
-                    metadata.pixel_format = jpeg_decoder::PixelFormat::RGB24;
-                }
-
-                self.metadata = Some(metadata);
-                Ok(metadata)
-            }
-        }
+        Ok(JPEGDecoder {
+            decoder,
+            metadata,
+        })
     }
 }
 
 impl<R: Read> ImageDecoder for JPEGDecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        let metadata = try!(self.metadata());
-        Ok((u32::from(metadata.width), u32::from(metadata.height)))
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        (u32::from(self.metadata.width), u32::from(self.metadata.height))
     }
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        let metadata = try!(self.metadata());
-        Ok(metadata.pixel_format.into())
+    fn colortype(&self) -> ColorType {
+        self.metadata.pixel_format.into()
     }
 
-    fn row_len(&mut self) -> ImageResult<usize> {
-        let metadata = try!(self.metadata());
-        Ok(metadata.width as usize * color::num_components(metadata.pixel_format.into()))
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(self.read_image()?))
     }
 
-    fn read_scanline(&mut self, _buf: &mut [u8]) -> ImageResult<u32> {
-        unimplemented!();
-    }
-
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        let mut data = try!(self.decoder.decode());
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+        let mut data = self.decoder.decode()?;
         data = match self.decoder.info().unwrap().pixel_format {
             jpeg_decoder::PixelFormat::CMYK32 => cmyk_to_rgb(&data),
             _ => data,
         };
 
-        Ok(DecodingResult::U8(data))
+        Ok(data)
     }
 }
 

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -759,7 +759,7 @@ mod tests {
     use super::super::JPEGDecoder;
     use super::JPEGEncoder;
     use color::ColorType;
-    use image::{DecodingResult, ImageDecoder};
+    use image::ImageDecoder;
     use std::io::Cursor;
 
     #[test]
@@ -778,19 +778,15 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let mut decoder = JPEGDecoder::new(Cursor::new(&encoded_img));
-            match decoder.read_image().expect("Could not decode image") {
-                DecodingResult::U8(decoded) => {
-                    // note that, even with the encode quality set to 100, we
-                    // do not get the same image back. Therefore, we're going
-                    // to assert that it's at least red-ish:
-                    assert_eq!(3, decoded.len());
-                    assert!(decoded[0] > 0x80);
-                    assert!(decoded[1] < 0x80);
-                    assert!(decoded[2] < 0x80);
-                }
-                _ => panic!("Image did not decode as 8-bit"),
-            }
+            let decoder = JPEGDecoder::new(Cursor::new(&encoded_img))
+                .expect("Could not decode image");
+            let decoded = decoder.read_image().expect("Could not decode image");
+            // note that, even with the encode quality set to 100, we do not get the same image
+            // back. Therefore, we're going to assert that it's at least red-ish:
+            assert_eq!(3, decoded.len());
+            assert!(decoded[0] > 0x80);
+            assert!(decoded[1] < 0x80);
+            assert!(decoded[2] < 0x80);
         }
     }
 
@@ -810,20 +806,16 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let mut decoder = JPEGDecoder::new(Cursor::new(&encoded_img));
-            match decoder.read_image().expect("Could not decode image") {
-                DecodingResult::U8(decoded) => {
-                    // note that, even with the encode quality set to 100, we
-                    // do not get the same image back. Therefore, we're going
-                    // to assert that the diagonal is at least white-ish:
-                    assert_eq!(4, decoded.len());
-                    assert!(decoded[0] > 0x80);
-                    assert!(decoded[1] < 0x80);
-                    assert!(decoded[2] < 0x80);
-                    assert!(decoded[3] > 0x80);
-                }
-                _ => panic!("Image did not decode as 8-bit"),
-            }
+            let decoder = JPEGDecoder::new(Cursor::new(&encoded_img))
+                .expect("Could not decode image");
+            let decoded = decoder.read_image().expect("Could not decode image");
+            // note that, even with the encode quality set to 100, we do not get the same image
+            // back. Therefore, we're going to assert that the diagonal is at least white-ish:
+            assert_eq!(4, decoded.len());
+            assert!(decoded[0] > 0x80);
+            assert!(decoded[1] < 0x80);
+            assert!(decoded[2] < 0x80);
+            assert!(decoded[3] > 0x80);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,11 @@ pub use color::ColorType::{self, Gray, GrayA, Palette, RGB, RGBA, BGR, BGRA};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
-pub use image::{DecodingResult,
+pub use image::{AnimationDecoder,
                 GenericImage,
                 GenericImageView,
                 ImageDecoder,
+                ImageDecoderExt,
                 ImageError,
                 ImageResult,
                 MutPixels,

--- a/src/png.rs
+++ b/src/png.rs
@@ -10,78 +10,57 @@ extern crate png;
 
 use self::png::HasParameters;
 
-use std::io::{self, Read, Write};
+use std::io::{self, Cursor, Read, Write};
 
 use color::ColorType;
-use image::{DecodingResult, ImageDecoder, ImageError, ImageResult};
-
-enum Either<T, U> {
-    Left(T),
-    Right(U),
-}
+use image::{ImageDecoder, ImageError, ImageResult};
 
 /// PNG decoder
 pub struct PNGDecoder<R: Read> {
-    inner: Option<Either<png::Decoder<R>, png::Reader<R>>>,
+    colortype: ColorType,
+    reader: png::Reader<R>,
 }
 
 impl<R: Read> PNGDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> PNGDecoder<R> {
-        PNGDecoder {
-            inner: Some(Either::Left(png::Decoder::new(r))),
-        }
-    }
+    pub fn new(r: R) -> ImageResult<PNGDecoder<R>> {
+        let decoder = png::Decoder::new(r);
+        let (_, mut reader) = decoder.read_info()?;
+        let colortype = reader.output_color_type().into();
 
-    // Converts the inner decoder to a reader
-    fn get_reader(&mut self) -> Result<&mut png::Reader<R>, png::DecodingError> {
-        let inner = self.inner.take().unwrap();
-        self.inner = Some(match inner {
-            Either::Left(decoder) => {
-                let (_, reader) = try!(decoder.read_info());
-                Either::Right(reader)
-            }
-            Either::Right(reader) => Either::Right(reader),
-        });
-        match self.inner {
-            Some(Either::Right(ref mut reader)) => Ok(reader),
-            _ => unreachable!(),
-        }
+        Ok(PNGDecoder { colortype, reader })
     }
 }
 
 impl<R: Read> ImageDecoder for PNGDecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        let reader = try!(self.get_reader());
-        Ok(reader.info().size())
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        self.reader.info().size()
     }
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        let reader = try!(self.get_reader());
-        Ok(reader.output_color_type().into())
+    fn colortype(&self) -> ColorType {
+        self.colortype
     }
 
-    fn row_len(&mut self) -> ImageResult<usize> {
-        let reader = try!(self.get_reader());
-        let width = reader.info().width;
-        Ok(reader.output_line_size(width))
+    // fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
+    //     match try!(try!(self.get_reader()).next_row()) {
+    //         Some(line) => {
+    //             ::copy_memory(line, &mut buf[..line.len()]);
+    //             Ok(line.len() as u32)
+    //         }
+    //         None => Err(ImageError::ImageEnd),
+    //     }
+    // }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(self.read_image()?))
     }
 
-    fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
-        match try!(try!(self.get_reader()).next_row()) {
-            Some(line) => {
-                ::copy_memory(line, &mut buf[..line.len()]);
-                Ok(line.len() as u32)
-            }
-            None => Err(ImageError::ImageEnd),
-        }
-    }
-
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        let reader = try!(self.get_reader());
-        let mut data = vec![0; reader.output_buffer_size()];
-        try!(reader.next_frame(&mut data));
-        Ok(DecodingResult::U8(data))
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+        let mut data = vec![0; self.reader.output_buffer_size()];
+        self.reader.next_frame(&mut data)?;
+        Ok(data)
     }
 }
 

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -1,13 +1,13 @@
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{self, BufRead, BufReader, Cursor, Read};
 use std::str::{self, FromStr};
 use std::fmt::Display;
 
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
 use color::ColorType;
-use image::{DecodingResult, ImageDecoder, ImageError, ImageResult};
+use image::{ImageDecoder, ImageError, ImageResult};
 
-use byteorder::{BigEndian, ByteOrder};
+use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
 /// Dynamic representation, represents all decodable (sample, depth) combinations.
 #[derive(Clone, Copy)]
@@ -21,15 +21,14 @@ enum TupleType {
 }
 
 trait Sample {
-    type T;
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize>;
 
     /// It is guaranteed that `bytes.len() == bytelen(width, height, samples)`
     fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32)
-        -> ImageResult<Vec<Self::T>>;
+        -> ImageResult<Vec<u8>>;
 
     fn from_ascii(reader: &mut Read, width: u32, height: u32, samples: u32)
-        -> ImageResult<Vec<Self::T>>;
+        -> ImageResult<Vec<u8>>;
 }
 
 struct U8;
@@ -402,40 +401,27 @@ trait HeaderReader: BufRead {
 impl<R: Read> HeaderReader for BufReader<R> {}
 
 impl<R: Read> ImageDecoder for PNMDecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        Ok((self.header.width(), self.header.height()))
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        (self.header.width(), self.header.height())
     }
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        Ok(self.tuple.color())
+    fn colortype(&self) -> ColorType {
+        self.tuple.color()
     }
 
-    fn row_len(&mut self) -> ImageResult<usize> {
-        self.rowlen()
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(self.read_image()?))
     }
 
-    fn read_scanline(&mut self, _buf: &mut [u8]) -> ImageResult<u32> {
-        unimplemented!();
-    }
-
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
         self.read()
     }
 }
 
 impl<R: Read> PNMDecoder<R> {
-    fn rowlen(&self) -> ImageResult<usize> {
-        match self.tuple {
-            TupleType::PbmBit => PbmBit::bytelen(self.header.width(), 1, 1),
-            TupleType::BWBit => BWBit::bytelen(self.header.width(), 1, 1),
-            TupleType::RGBU8 => U8::bytelen(self.header.width(), 1, 3),
-            TupleType::RGBU16 => U16::bytelen(self.header.width(), 1, 3),
-            TupleType::GrayU8 => U8::bytelen(self.header.width(), 1, 1),
-            TupleType::GrayU16 => U16::bytelen(self.header.width(), 1, 1),
-        }
-    }
-
-    fn read(&mut self) -> ImageResult<DecodingResult> {
+    fn read(&mut self) -> ImageResult<Vec<u8>> {
         match self.tuple {
             TupleType::PbmBit => self.read_samples::<PbmBit>(1),
             TupleType::BWBit => self.read_samples::<BWBit>(1),
@@ -446,10 +432,7 @@ impl<R: Read> PNMDecoder<R> {
         }
     }
 
-    fn read_samples<S: Sample>(&mut self, components: u32) -> ImageResult<DecodingResult>
-    where
-        Vec<S::T>: Into<DecodingResult>,
-    {
+    fn read_samples<S: Sample>(&mut self, components: u32) -> ImageResult<Vec<u8>> {
         match self.subtype().sample_encoding() {
             SampleEncoding::Binary => {
                 let width = self.header.width();
@@ -469,7 +452,7 @@ impl<R: Read> PNMDecoder<R> {
         }
     }
 
-    fn read_ascii<Basic: Sample>(&mut self, components: u32) -> ImageResult<Vec<Basic::T>> {
+    fn read_ascii<Basic: Sample>(&mut self, components: u32) -> ImageResult<Vec<u8>> {
         Basic::from_ascii(&mut self.reader, self.header.width(), self.header.height(), components)
     }
 
@@ -523,8 +506,6 @@ fn read_separated_ascii<T: FromStr>(reader: &mut Read) -> ImageResult<T>
 }
 
 impl Sample for U8 {
-    type T = u8;
-
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
         Ok((width * height * samples) as usize)
     }
@@ -534,7 +515,7 @@ impl Sample for U8 {
         _width: u32,
         _height: u32,
         _samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         let mut buffer = Vec::new();
         buffer.resize(bytes.len(), 0 as u8);
         buffer.copy_from_slice(bytes);
@@ -546,7 +527,7 @@ impl Sample for U8 {
         width: u32,
         height: u32,
         samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         (0..width*height*samples)
             .map(|_| read_separated_ascii(reader))
             .collect()
@@ -554,8 +535,6 @@ impl Sample for U8 {
 }
 
 impl Sample for U16 {
-    type T = u16;
-
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
         Ok((width * height * samples * 2) as usize)
     }
@@ -565,10 +544,14 @@ impl Sample for U16 {
         width: u32,
         height: u32,
         samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
-        let mut buffer = Vec::new();
-        buffer.resize((width * height * samples) as usize, 0 as u16);
-        BigEndian::read_u16_into(bytes, &mut buffer);
+    ) -> ImageResult<Vec<u8>> {
+        assert_eq!(bytes.len(), (width*height*samples*2) as usize);
+
+        let mut buffer = bytes.to_vec();
+        for chunk in buffer.chunks_mut(2) {
+            let v = BigEndian::read_u16(chunk);
+            NativeEndian::write_u16(chunk, v);
+        }
         Ok(buffer)
     }
 
@@ -577,10 +560,13 @@ impl Sample for U16 {
         width: u32,
         height: u32,
         samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
-        (0..width*height*samples)
-            .map(|_| read_separated_ascii(reader))
-            .collect()
+    ) -> ImageResult<Vec<u8>> {
+        let mut buffer = vec![0; (width * height * samples * 2) as usize];
+        for i in 0..(width*height*samples) as usize {
+            let v = read_separated_ascii::<u16>(reader)?;
+            NativeEndian::write_u16(&mut buffer[2*i..][..2], v);
+        }
+        Ok(buffer)
     }
 }
 
@@ -588,8 +574,6 @@ impl Sample for U16 {
 // be ignored. Also, contrary to rgb, black pixels are encoded as a 1 while white is 0. This will
 // need to be reversed for the grayscale output.
 impl Sample for PbmBit {
-    type T = u8;
-
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
         let count = width * samples;
         let linelen = (count / 8) + ((count % 8) != 0) as u32;
@@ -601,7 +585,7 @@ impl Sample for PbmBit {
         _width: u32,
         _height: u32,
         _samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         Ok(bytes.iter().map(|pixel| !pixel).collect())
     }
 
@@ -610,7 +594,7 @@ impl Sample for PbmBit {
         width: u32,
         height: u32,
         samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         let count = (width*height*samples) as usize;
         let raw_samples = reader.bytes()
             .filter_map(|ascii| match ascii {
@@ -628,7 +612,7 @@ impl Sample for PbmBit {
                     ))),
             })
             .take(count)
-            .collect::<ImageResult<Vec<Self::T>>>()?;
+            .collect::<ImageResult<Vec<u8>>>()?;
 
         if raw_samples.len() < count {
             return Err(ImageError::NotEnoughData)
@@ -640,8 +624,6 @@ impl Sample for PbmBit {
 
 // Encoded just like a normal U8 but we check the values.
 impl Sample for BWBit {
-    type T = u8;
-
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
         U8::bytelen(width, height, samples)
     }
@@ -651,7 +633,7 @@ impl Sample for BWBit {
         width: u32,
         height: u32,
         samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         let values = U8::from_bytes(bytes, width, height, samples)?;
         if let Some(val) = values.iter().find(|&val| *val > 1) {
             return Err(ImageError::FormatError(
@@ -666,20 +648,8 @@ impl Sample for BWBit {
         _width: u32,
         _height: u32,
         _samples: u32,
-    ) -> ImageResult<Vec<Self::T>> {
+    ) -> ImageResult<Vec<u8>> {
         unreachable!("BW bits from anymaps are never encoded as ascii")
-    }
-}
-
-impl Into<DecodingResult> for Vec<u8> {
-    fn into(self) -> DecodingResult {
-        DecodingResult::U8(self)
-    }
-}
-
-impl Into<DecodingResult> for Vec<u16> {
-    fn into(self) -> DecodingResult {
-        DecodingResult::U16(self)
     }
 }
 
@@ -778,21 +748,17 @@ TUPLTYPE BLACKANDWHITE
 # Comment line
 ENDHDR
 \x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01";
-        let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(
-                data,
-                vec![
-                    0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01,
-                    0x00, 0x00, 0x01,
-                ]
-            ),
-        }
-        match decoder.into_inner() {
+
+        assert_eq!(
+            decoder.read_image().unwrap(),
+            vec![0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00,
+                 0x00, 0x01]
+        );
+        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -823,21 +789,16 @@ TUPLTYPE GRAYSCALE
 # Comment line
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
-        let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(
-                data,
-                vec![
-                    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde,
-                    0xad, 0xbe, 0xef,
-                ]
-            ),
-        }
-        match decoder.into_inner() {
+        assert_eq!(
+            decoder.read_image().unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
+                 0xbe, 0xef]
+        );
+        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -868,20 +829,14 @@ WIDTH 2
 HEIGHT 2
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
-        let mut decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
-        assert_eq!(decoder.dimensions().unwrap(), (2, 2));
+        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::RGB(8));
+        assert_eq!(decoder.dimensions(), (2, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(
-                data,
-                vec![
-                    0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
-                ]
-            ),
-        }
-        match decoder.into_inner() {
+
+        assert_eq!(decoder.read_image().unwrap(),
+                   vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]);
+        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -905,18 +860,15 @@ ENDHDR
         // The data contains two rows of the image (each line is padded to the full byte). For
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = [&b"P4 6 2\n"[..], &[0b01101100 as u8, 0b10110111]].concat();
-        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        assert_eq!(decoder.dimensions().unwrap(), (6, 2));
+        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(
             decoder.subtype(),
             PNMSubtype::Bitmap(SampleEncoding::Binary)
         );
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(data, vec![0b10010011, 0b01001000]),
-        }
-        match decoder.into_inner() {
+        assert_eq!(decoder.read_image().unwrap(), vec![0b10010011, 0b01001000]);
+        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -963,15 +915,12 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.  Tests all
         // whitespace characters that should be allowed (the 6 characters according to POSIX).
         let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0\t\n\x0b\x0c\r1";
-        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        assert_eq!(decoder.dimensions().unwrap(), (6, 2));
+        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(data, vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]),
-        }
-        match decoder.into_inner() {
+        assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
+        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -994,15 +943,12 @@ ENDHDR
         // it is completely within specification for the ascii data not to contain separating
         // whitespace for the pbm format or any mix.
         let pbmbinary = b"P1 6 2\n011011101101";
-        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(1));
-        assert_eq!(decoder.dimensions().unwrap(), (6, 2));
+        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(data, vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]),
-        }
-        match decoder.into_inner() {
+        assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
+        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -1025,18 +971,15 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let elements = (0..16).collect::<Vec<_>>();
         let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
-        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
             PNMSubtype::Graymap(SampleEncoding::Binary)
         );
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(data, elements),
-        }
-        match decoder.into_inner() {
+        assert_eq!(decoder.read_image().unwrap(), elements);
+        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -1059,18 +1002,15 @@ ENDHDR
         // The data contains two rows of the image (each line is padded to the full byte). For
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
-        let mut decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
-        assert_eq!(decoder.dimensions().unwrap(), (4, 4));
+        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
             PNMSubtype::Graymap(SampleEncoding::Ascii)
         );
-        match decoder.read_image().unwrap() {
-            DecodingResult::U16(_) => panic!("Decoded wrong image format"),
-            DecodingResult::U8(data) => assert_eq!(data, (0..16).collect::<Vec<_>>()),
-        }
-        match decoder.into_inner() {
+        assert_eq!(decoder.read_image().unwrap(), (0..16).collect::<Vec<_>>());
+        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -3,10 +3,7 @@ use std::io;
 use std::io::{Read, Seek};
 
 use color::ColorType;
-use image::DecodingResult;
-use image::ImageDecoder;
-use image::ImageError;
-use image::ImageResult;
+use image::{ImageDecoder, ImageError, ImageReadBuffer, ImageResult};
 
 enum ImageType {
     NoImageData = 0,
@@ -177,8 +174,8 @@ pub struct TGADecoder<R> {
 
 impl<R: Read + Seek> TGADecoder<R> {
     /// Create a new decoder that decodes from the stream `r`
-    pub fn new(r: R) -> TGADecoder<R> {
-        TGADecoder {
+    pub fn new(r: R) -> ImageResult<TGADecoder<R>> {
+        let mut decoder = TGADecoder {
             r,
 
             width: 0,
@@ -194,7 +191,9 @@ impl<R: Read + Seek> TGADecoder<R> {
 
             line_read: None,
             line_remain_buff: Vec::new(),
-        }
+        };
+        decoder.read_metadata()?;
+        Ok(decoder)
     }
 
     fn read_header(&mut self) -> ImageResult<()> {
@@ -343,7 +342,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     }
 
     /// Reads a run length encoded data for given number of bytes
-    fn read_encoded_data(&mut self, num_bytes: usize) -> ImageResult<Vec<u8>> {
+    fn read_encoded_data(&mut self, num_bytes: usize) -> io::Result<Vec<u8>> {
         let mut pixel_data = Vec::with_capacity(num_bytes);
 
         while pixel_data.len() < num_bytes {
@@ -384,11 +383,11 @@ impl<R: Read + Seek> TGADecoder<R> {
     fn read_all_encoded_data(&mut self) -> ImageResult<Vec<u8>> {
         let num_bytes = self.width * self.height * self.bytes_per_pixel;
 
-        self.read_encoded_data(num_bytes)
+        Ok(self.read_encoded_data(num_bytes)?)
     }
 
     /// Reads a run length encoded line
-    fn read_encoded_line(&mut self) -> ImageResult<Vec<u8>> {
+    fn read_encoded_line(&mut self) -> io::Result<Vec<u8>> {
         let line_num_bytes = self.width * self.bytes_per_pixel;
         let remain_len = self.line_remain_buff.len();
 
@@ -465,43 +464,21 @@ impl<R: Read + Seek> TGADecoder<R> {
         let screen_origin_bit = 0b10_0000 & self.header.image_desc != 0;
         !screen_origin_bit
     }
-}
 
-impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        try!(self.read_metadata());
-
-        Ok((self.width as u32, self.height as u32))
-    }
-
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        try!(self.read_metadata());
-
-        Ok(self.color_type)
-    }
-
-    fn row_len(&mut self) -> ImageResult<usize> {
-        try!(self.read_metadata());
-
-        Ok(self.bytes_per_pixel * self.width)
-    }
-
-    fn read_scanline(&mut self, buf: &mut [u8]) -> ImageResult<u32> {
-        try!(self.read_metadata());
-
+    fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Some(line_read) = self.line_read {
             if line_read == self.height {
-                return Err(ImageError::ImageEnd);
+                return Ok(0);
             }
         }
 
         // read the pixels from the data region
         let mut pixel_data = if self.image_type.is_encoded() {
-            try!(self.read_encoded_line())
+            self.read_encoded_line()?
         } else {
             let num_raw_bytes = self.width * self.bytes_per_pixel;
             let mut buf = vec![0; num_raw_bytes];
-            try!(self.r.by_ref().read_exact(&mut buf));
+            self.r.by_ref().read_exact(&mut buf)?;
             buf
         };
 
@@ -514,18 +491,43 @@ impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
         // copy to the output buffer
         buf[..pixel_data.len()].copy_from_slice(&pixel_data);
 
-        let mut row_index = self.line_read.unwrap_or(0) + 1;
-        self.line_read = Some(row_index);
+        self.line_read = Some(self.line_read.unwrap_or(0) + 1);
 
-        if self.is_flipped_vertically() {
-            row_index = self.height - (row_index - 1);
-        }
-
-        Ok(row_index as u32)
-    }
-
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        try!(self.read_metadata());
-        self.read_image_data().map(DecodingResult::U8)
+        Ok(pixel_data.len())
     }
 }
+
+impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
+    type Reader = TGAReader<R>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        (self.width as u32, self.height as u32)
+    }
+
+    fn colortype(&self) -> ColorType {
+        self.color_type
+    }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(TGAReader {
+            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
+            decoder: self,
+        })
+    }
+
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+        self.read_image_data()
+    }
+}
+
+pub struct TGAReader<R> {
+    buffer: ImageReadBuffer,
+    decoder: TGADecoder<R>,
+}
+impl<R: Read + Seek> Read for TGAReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let ref mut decoder = &mut self.decoder;
+        self.buffer.read(buf, |buf| decoder.read_scanline(buf))
+    }
+}
+

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -9,15 +9,17 @@
 extern crate tiff;
 
 use color::ColorType;
-use image::{DecodingResult, ImageDecoder, ImageResult, ImageError};
+use image::{ImageDecoder, ImageResult, ImageError};
 
-use std::io::{Read, Seek};
+use std::io::{Cursor, Read, Seek};
 
 /// Decoder for TIFF images.
 pub struct TIFFDecoder<R>
     where R: Read + Seek
 {
-    inner: tiff::decoder::Decoder<R>
+    dimensions: (u32, u32),
+    colortype: ColorType,
+    inner: tiff::decoder::Decoder<R>,
 }
 
 impl<R> TIFFDecoder<R>
@@ -25,7 +27,15 @@ impl<R> TIFFDecoder<R>
 {
     /// Create a new TIFFDecoder.
     pub fn new(r: R) -> Result<TIFFDecoder<R>, ImageError> {
-        Ok(TIFFDecoder { inner: tiff::decoder::Decoder::new(r)? })
+        let mut inner = tiff::decoder::Decoder::new(r)?;
+        let dimensions = inner.dimensions()?;
+        let colortype = inner.colortype()?.into();
+
+        Ok(TIFFDecoder {
+            dimensions,
+            colortype,
+            inner,
+        })
     }
 }
 
@@ -52,33 +62,32 @@ impl From<tiff::ColorType> for ColorType {
     }
 }
 
-impl From<tiff::decoder::DecodingResult> for DecodingResult {
-    fn from(res: tiff::decoder::DecodingResult) -> DecodingResult {
-        match res {
-            tiff::decoder::DecodingResult::U8(data) => DecodingResult::U8(data),
-            tiff::decoder::DecodingResult::U16(data) => DecodingResult::U16(data),
-        }
-    }
-}
-
 impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
-    fn dimensions(&mut self) -> ImageResult<(u32, u32)> {
-        self.inner.dimensions().map_err(|e| e.into())
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        self.dimensions
     }
 
-    fn colortype(&mut self) -> ImageResult<ColorType> {
-        Ok(self.inner.colortype()?.into())
+    fn colortype(&self) -> ColorType {
+        self.colortype
     }
 
-    fn row_len(&mut self) -> ImageResult<usize> {
-        unimplemented!()
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(self.read_image()?))
     }
 
-    fn read_scanline(&mut self, _: &mut [u8]) -> ImageResult<u32> {
-        unimplemented!()
-    }
+    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+        match self.inner.read_image()? {
+            tiff::decoder::DecodingResult::U8(v) => Ok(v),
+            tiff::decoder::DecodingResult::U16(mut v) => {
+                let p: *mut u16 = v.as_mut_ptr();
+                let len = v.len();
+                let cap = v.capacity();
 
-    fn read_image(&mut self) -> ImageResult<DecodingResult> {
-        self.inner.read_image().map_err(|e| e.into()).map(|res| res.into())
+                // TODO: get rid of this unsafe block somehow
+                unsafe { Ok(Vec::<u8>::from_raw_parts(p as *mut u8, len*2, cap*2)) }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Overview
This pull request implements #798. The general motivation is that the existing `ImageDecoder` trait has some limitations which would be good to address before this crate reaches 1.0. This is necessarily a breaking change.

## Goals
* Address inconsistent naming: `load_rect` vs `read_image`.
* Fix lack of idempotence: typically only the first call to `read_image` returns the correct result (though this doesn't seem to be documented anywhere?)
   - These functions now consume self.
* Avoid unimplemented methods: many decoders currently leave `read_scanline` unimplemented.
   - No decoders panic on any of the methods for `ImageDecoder`. Implementions of `ImageDecoderExt` are still a work in progress, but will all have at least naive implementations.
* Eliminate inconsistent behavior: for instance, #709 
   - All methods now have clear semantics (I hope?)

## Trait Definitions
```rust
pub trait ImageDecoder: Sized {
    type Reader: Read;
    fn dimensions(&self) -> (u32, u32);
    fn colortype(&self) -> ColorType;
    fn into_reader(self) -> ImageResult<Self::Reader>;

    fn row_bytes(&self) -> usize { ... }
    fn total_bytes(&self) -> usize { ... }
    fn scanline_bytes(&self) -> usize { ... }
    fn read_image(self) -> ImageResult<Vec<u8>> { ... }
    fn read_image_with_progress<F: Fn(Progress)>(
        self, 
        progress_callback: F
    ) -> ImageResult<Vec<u8>> { ... }
}
```
```rust
// This trait requires an underlying reader that has the ability to `Seek`.
pub trait DecoderExt: ImageDecoder + Sized {
    // If possible for the image type, this function uses seek() to load only the
    // needed parts of the image into memory. Regardless, it then seeks back to the
    // start so `read_image` and friends still work.
    fn read_rect(
        &mut self, 
        x: u32, 
        y: u32, 
        width: u32, 
        height: u32, 
        buf: &mut [u8]
    ) -> ImageResult<Vec<u8>>;
}
```

## Outstanding questions
- [ ] Are the current choices for integer types correct? Specifically image sizes being `u32` and sizes of rows, scanlines, and images being `usize`? 
- [ ] Is getting rid of `DecodingResult` the right move?
- [ ] Should we take this opportunity to remove other deprecated functionality?