### PR TITLE
Use Rust 1.24.1 as minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
     - linux
     - osx
 rust:
+    - 1.24.1
     - stable
     - beta
     - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.20.0"
+version = "0.20.1"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -503,7 +503,7 @@ fn read_separated_ascii<T: FromStr>(reader: &mut Read) -> ImageResult<T>
 
     let token = reader
         .bytes()
-        .skip_while(|v| v.as_ref().ok().map(is_separator).unwrap_or(false))
+        .skip_while(|v| v.as_ref().ok().map(&is_separator).unwrap_or(false))
         .take_while(|v| v.as_ref().ok().map(|c| !is_separator(c)).unwrap_or(false))
         .collect::<Result<Vec<u8>, _>>()?;
 


### PR DESCRIPTION
Resolves #482 

I've also bumped the patch version; it would be super lovely if this could be released, since it's currently blocking the release of winit 0.18.0.