### PR TITLE
Correct to_bgra docstring for DynamicImage

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -158,7 +158,7 @@ impl DynamicImage {
         })
     }
 
-    /// Returns a copy of this image as an RGBA image.
+    /// Returns a copy of this image as an BGRA image.
     pub fn to_bgra(&self) -> BgraImage {
         dynamic_map!(*self, ref p -> {
             p.convert()


### PR DESCRIPTION
The docstring says RGBA when it should say BGRA, this PR corrects it.