### PR TITLE
bmp/encoder: encode RGBA using bitfields with alpha mask

### DIFF
--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -3,6 +3,10 @@ use std::io::{self, Write};
 
 use color;
 
+const BITMAPFILEHEADER_SIZE: u32 = 14;
+const BITMAPINFOHEADER_SIZE: u32 = 40;
+const BITMAPV4HEADER_SIZE: u32 = 108;
+
 /// The representation of a BMP encoder.
 pub struct BMPEncoder<'a, W: 'a> {
     writer: &'a mut W,
@@ -24,10 +28,9 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         height: u32,
         c: color::ColorType,
     ) -> io::Result<()> {
-        let bmp_header_size = 14;
-        let dib_header_size = 40; // using BITMAPINFOHEADER
+        let bmp_header_size = BITMAPFILEHEADER_SIZE;
 
-        let (raw_pixel_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(c));
+        let (dib_header_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(c));
         let row_pad_size = (4 - (width * written_pixel_size) % 4) % 4; // each row must be padded to a multiple of 4 bytes
 
         let image_size = width * height * written_pixel_size + (height * row_pad_size);
@@ -54,20 +57,43 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             self.writer
                 .write_u16::<LittleEndian>((written_pixel_size * 8) as u16)
         ); // bits per pixel
-        try!(self.writer.write_u32::<LittleEndian>(0)); // compression method - no compression
+        if dib_header_size >= BITMAPV4HEADER_SIZE {
+            // Assume BGRA32
+            try!(self.writer.write_u32::<LittleEndian>(3)); // compression method - bitfields
+        } else {
+            try!(self.writer.write_u32::<LittleEndian>(0)); // compression method - no compression
+        }
         try!(self.writer.write_u32::<LittleEndian>(image_size));
         try!(self.writer.write_i32::<LittleEndian>(0)); // horizontal ppm
         try!(self.writer.write_i32::<LittleEndian>(0)); // vertical ppm
         try!(self.writer.write_u32::<LittleEndian>(palette_color_count));
         try!(self.writer.write_u32::<LittleEndian>(0)); // all colors are important
+        if dib_header_size >= BITMAPV4HEADER_SIZE {
+            // Assume BGRA32
+            try!(self.writer.write_u32::<LittleEndian>(0xff << 16)); // red mask
+            try!(self.writer.write_u32::<LittleEndian>(0xff << 8)); // green mask
+            try!(self.writer.write_u32::<LittleEndian>(0xff << 0)); // blue mask
+            try!(self.writer.write_u32::<LittleEndian>(0xff << 24)); // alpha mask
+            try!(self.writer.write_u32::<LittleEndian>(0x73524742)); // colorspace - sRGB
+            // endpoints (3x3) and gamma (3)
+            for _ in 0..12 {
+                try!(self.writer.write_u32::<LittleEndian>(0));
+            }
+        }
 
         // write image data
         match c {
-            color::ColorType::RGB(8) | color::ColorType::RGBA(8) => {
-                try!(self.encode_rgb(image, width, height, row_pad_size, raw_pixel_size))
+            color::ColorType::RGB(8) => {
+                try!(self.encode_rgb(image, width, height, row_pad_size, 3))
             }
-            color::ColorType::Gray(8) | color::ColorType::GrayA(8) => {
-                try!(self.encode_gray(image, width, height, row_pad_size, raw_pixel_size))
+            color::ColorType::RGBA(8) => {
+                try!(self.encode_rgba(image, width, height, row_pad_size, 4))
+            }
+            color::ColorType::Gray(8) => {
+                try!(self.encode_gray(image, width, height, row_pad_size, 1))
+            }
+            color::ColorType::GrayA(8) => {
+                try!(self.encode_gray(image, width, height, row_pad_size, 2))
             }
             _ => {
                 return Err(io::Error::new(
@@ -103,6 +129,38 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
                 try!(self.writer.write_u8(g));
                 try!(self.writer.write_u8(r));
                 // alpha is never written as it's not widely supported
+            }
+
+            try!(self.write_row_pad(row_pad_size));
+        }
+
+        Ok(())
+    }
+
+    fn encode_rgba(
+        &mut self,
+        image: &[u8],
+        width: u32,
+        height: u32,
+        row_pad_size: u32,
+        bytes_per_pixel: u32,
+    ) -> io::Result<()> {
+        let x_stride = bytes_per_pixel;
+        let y_stride = width * x_stride;
+        for row in 0..height {
+            // from the bottom up
+            let row_start = (height - row - 1) * y_stride;
+            for col in 0..width {
+                let pixel_start = (row_start + (col * x_stride)) as usize;
+                let r = image[pixel_start];
+                let g = image[pixel_start + 1];
+                let b = image[pixel_start + 2];
+                let a = image[pixel_start + 3];
+                // written as BGRA
+                try!(self.writer.write_u8(b));
+                try!(self.writer.write_u8(g));
+                try!(self.writer.write_u8(r));
+                try!(self.writer.write_u8(a));
             }
 
             try!(self.write_row_pad(row_pad_size));
@@ -164,13 +222,13 @@ fn get_unsupported_error_message(c: color::ColorType) -> String {
     )
 }
 
-/// Returns a tuple representing: (raw pixel size, written pixel size, palette color count).
+/// Returns a tuple representing: (dib header size, written pixel size, palette color count).
 fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
     let sizes = match c {
-        color::ColorType::RGB(8) => (3, 3, 0),
-        color::ColorType::RGBA(8) => (4, 3, 0),
-        color::ColorType::Gray(8) => (1, 1, 256),
-        color::ColorType::GrayA(8) => (2, 1, 256),
+        color::ColorType::RGB(8) => (BITMAPINFOHEADER_SIZE, 3, 0),
+        color::ColorType::RGBA(8) => (BITMAPV4HEADER_SIZE, 4, 0),
+        color::ColorType::Gray(8) => (BITMAPINFOHEADER_SIZE, 1, 256),
+        color::ColorType::GrayA(8) => (BITMAPINFOHEADER_SIZE, 1, 256),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -218,12 +276,9 @@ mod tests {
 
     #[test]
     fn round_trip_single_pixel_rgba() {
-        let image = [255u8, 0, 0, 0]; // single red pixel
+        let image = [1, 2, 3, 4];
         let decoded = round_trip_image(&image, 1, 1, ColorType::RGBA(8));
-        assert_eq!(3, decoded.len());
-        assert_eq!(255, decoded[0]);
-        assert_eq!(0, decoded[1]);
-        assert_eq!(0, decoded[2]);
+        assert_eq!(&decoded[..], &image[..]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #840 
cc @kvark 