### PR TITLE
Remove several instances of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
 lzw = "0.10.0"
+safe-transmute = "0.10.1"
 
 [dependencies.gif]
 version = "0.10.0"

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -620,8 +620,7 @@ fn decode_old_rle<R: BufRead>(
 fn read_rgbe<R: BufRead>(r: &mut R) -> io::Result<RGBE8Pixel> {
     let mut buf = [0u8; 4];
     try!(r.read_exact(&mut buf[..]));
-    // It's actually safe: RGBE8Pixel is repr(C) and it doesn't implement Drop
-    Ok(unsafe { ::std::mem::transmute(buf) })
+    Ok(RGBE8Pixel {c: [buf[0], buf[1], buf[2]], e: buf[3] })
 }
 
 /// Metadata for Radiance HDR image

--- a/src/hdr/hdr_encoder.rs
+++ b/src/hdr/hdr_encoder.rs
@@ -221,11 +221,7 @@ fn rle_compress(data: &[u8], rle: &mut Vec<u8>) {
 }
 
 fn write_rgbe8<W: Write>(w: &mut W, v: RGBE8Pixel) -> Result<()> {
-    let buf: [u8; 4] = unsafe {
-        // It's safe, RGBE8Pixel doesn't implement Drop and it is repr(C)
-        ::std::mem::transmute(v)
-    };
-    w.write_all(&buf[..])
+    w.write_all(&[v.c[0], v.c[1], v.c[2], v.e])
 }
 
 /// Converts ```Rgb<f32>``` into ```RGBE8Pixel```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate lzw;
 extern crate num_iter;
 extern crate num_rational;
 extern crate num_traits;
+extern crate safe_transmute;
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
 


### PR DESCRIPTION
These changes should have negligible performance impact, but reduce the amount of unsafe code in the crate.