### PR TITLE
fix imageops::overlay() range_height

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -57,7 +57,11 @@ pub fn overlay<I: GenericImage>(bottom: &mut I, top: &I, x: u32, y: u32) {
     };
 
     let range_height = if y + top_height > bottom_height {
-        bottom_height - y
+        if y < bottom_height {
+            bottom_height - y
+        } else {
+            0
+        }
     } else {
         top_height
     };


### PR DESCRIPTION
Fixes range_height calculation under certain conditions.

Without the fix, this caused a crash with input
// bottom_height 298
// top_height 32
// y 301

since 298 - 301 overflows u32