### PR TITLE
Unifies, fixes, checks and benchmarks `ImageBuffer` index calculation

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -801,4 +801,34 @@ mod test {
         });
         b.bytes = 1000 * 1000 * 3
     }
+
+    #[bench]
+    #[cfg(feature = "benchmarks")]
+    fn bench_image_access_good_cache(b: &mut test::Bencher) {
+        use buffer::{ImageBuffer, Pixel};
+
+        let mut a: RgbImage = ImageBuffer::new(1000, 1000);
+        for mut p in a.pixels_mut() {
+            let rgb = p.channels_mut();
+            rgb[0] = 255;
+            rgb[1] = 23;
+            rgb[2] = 42;
+        }
+
+        b.iter(move || {
+            let image: &RgbImage = test::black_box(&a);
+            let mut sum: usize = 0;
+            for x in 0..1000 {
+                for y in 0..1000 {
+                    let pixel = image.get_pixel(x, y);
+                    sum = sum.wrapping_add(pixel[0] as usize);
+                    sum = sum.wrapping_add(pixel[1] as usize);
+                    sum = sum.wrapping_add(pixel[2] as usize);
+                }
+            }
+            test::black_box(sum)
+        });
+
+        b.bytes = 1000 * 1000 * 3;
+    }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -831,7 +831,37 @@ mod test {
 
     #[bench]
     #[cfg(feature = "benchmarks")]
-    fn bench_image_access_good_cache(b: &mut test::Bencher) {
+    fn bench_image_access_row_by_row(b: &mut test::Bencher) {
+        use buffer::{ImageBuffer, Pixel};
+
+        let mut a: RgbImage = ImageBuffer::new(1000, 1000);
+        for mut p in a.pixels_mut() {
+            let rgb = p.channels_mut();
+            rgb[0] = 255;
+            rgb[1] = 23;
+            rgb[2] = 42;
+        }
+
+        b.iter(move || {
+            let image: &RgbImage = test::black_box(&a);
+            let mut sum: usize = 0;
+            for y in 0..1000 {
+                for x in 0..1000 {
+                    let pixel = image.get_pixel(x, y);
+                    sum = sum.wrapping_add(pixel[0] as usize);
+                    sum = sum.wrapping_add(pixel[1] as usize);
+                    sum = sum.wrapping_add(pixel[2] as usize);
+                }
+            }
+            test::black_box(sum)
+        });
+
+        b.bytes = 1000 * 1000 * 3;
+    }
+
+    #[bench]
+    #[cfg(feature = "benchmarks")]
+    fn bench_image_access_col_by_col(b: &mut test::Bencher) {
         use buffer::{ImageBuffer, Pixel};
 
         let mut a: RgbImage = ImageBuffer::new(1000, 1000);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,7 @@
 use num_traits::Zero;
 use std::io;
 use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
 use std::slice::{Chunks, ChunksMut};
 
@@ -395,7 +395,7 @@ where
     }
 
     #[inline(always)]
-    fn pixel_indices(&self, x: u32, y: u32) -> Option<std::ops::Range<usize>> {
+    fn pixel_indices(&self, x: u32, y: u32) -> Option<Range<usize>> {
         if x >= self.width || y >= self.height {
             return None
         }
@@ -406,7 +406,7 @@ where
     }
 
     #[inline(always)]
-    unsafe fn unsafe_pixel_indices(&self, x: u32, y: u32) -> std::ops::Range<usize> {
+    unsafe fn unsafe_pixel_indices(&self, x: u32, y: u32) -> Range<usize> {
         let no_channels = <P as Pixel>::channel_count() as usize;
         // If in bounds, this can't overflow as we have tested that at construction!
         let min_index = (y as usize*self.width as usize + x as usize)*no_channels;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -372,11 +372,10 @@ where
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     pub fn get_pixel(&self, x: u32, y: u32) -> &P {
-        let pixel_indices = self.pixel_indices(x, y)
-            .unwrap_or_else(|| panic!(
-                "Image index {:?} out of bounds {:?}", (x, y), (self.width, self.height),
-            ));
-        <P as Pixel>::from_slice(&self.data[pixel_indices])
+        match self.pixel_indices(x, y) {
+            None => panic!("Image index {:?} out of bounds {:?}", (x, y), (self.width, self.height)),
+            Some(pixel_indices) => <P as Pixel>::from_slice(&self.data[pixel_indices]),
+        }
     }
 
     /// Test that the image fits inside the buffer.
@@ -447,11 +446,10 @@ where
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
-        let pixel_indices = self.pixel_indices(x, y)
-            .unwrap_or_else(|| panic!(
-                "Image index {:?} out of bounds {:?}", (x, y), (self.width, self.height),
-            ));
-        <P as Pixel>::from_slice_mut(&mut self.data[pixel_indices])
+        match self.pixel_indices(x, y) {
+            None => panic!("Image index {:?} out of bounds {:?}", (x, y), (self.width, self.height)),
+            Some(pixel_indices) => <P as Pixel>::from_slice_mut(&mut self.data[pixel_indices]),
+        }
     }
 
     /// Puts a pixel at location `(x, y)`

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -385,7 +385,7 @@ where
     /// the bounds will not overflow.
     fn check_image_fits(width: u32, height: u32, len: usize) -> bool {
         let checked_len = Self::image_buffer_len(width, height);
-        checked_len.map(|min_len| min_len < len).unwrap_or(false)
+        checked_len.map(|min_len| min_len <= len).unwrap_or(false)
     }
 
     fn image_buffer_len(width: u32, height: u32) -> Option<usize> {


### PR DESCRIPTION
Fixes #836 (and by extension addresses one of the issues in https://github.com/PistonDevelopers/imageproc/issues/281). I'll leave this open for a few more days or hours in case an additional idea for a performance improvement comes up (thanks @fintelia for the current calculation). Right now:

```
Before: test … bench:   1,541,207 ns/iter (+/- 224,258) = 1946 MB/s
After: test … bench:   1,759,194 ns/iter (+/- 62,646) = 1705 MB/s
```

That seems acceptable but maybe not yet optimal.