### PR TITLE
allow different image types in overlay and replace

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -117,7 +117,11 @@ pub fn overlay_bounds(
 }
 
 /// Overlay an image at a given coordinate (x, y)
-pub fn overlay<I: GenericImage>(bottom: &mut I, top: &I, x: u32, y: u32) {
+pub fn overlay<I, J>(bottom: &mut I, top: &J, x: u32, y: u32)
+where
+    I: GenericImage,
+    J: GenericImageView<Pixel = I::Pixel>,
+{
     let bottom_dims = bottom.dimensions();
     let top_dims = top.dimensions();
 
@@ -136,7 +140,11 @@ pub fn overlay<I: GenericImage>(bottom: &mut I, top: &I, x: u32, y: u32) {
 }
 
 /// Replace the contents of an image at a given coordinate (x, y)
-pub fn replace<I: GenericImage>(bottom: &mut I, top: &I, x: u32, y: u32) {
+pub fn replace<I, J>(bottom: &mut I, top: &J, x: u32, y: u32)
+where
+    I: GenericImage,
+    J: GenericImageView<Pixel = I::Pixel>,
+{
     let bottom_dims = bottom.dimensions();
     let top_dims = top.dimensions();
 


### PR DESCRIPTION
This commit allows the `bottom` and `top` parameters of `imageops::overlay` and `imageops::replace` to have different types.